### PR TITLE
🔧hotfix a bug in getting-started.py

### DIFF
--- a/examples/getting-started.py
+++ b/examples/getting-started.py
@@ -91,7 +91,7 @@ lazy_out = network(lazy_input)
 # but don't worry, no code modification is needed.
 # When backward is called, the LazyTensors would be automatically evaluated.
 lazy_loss = loss_fn(lazy_out, label)
-assert isinstance(lazy_loss, LazyTensor), type(lazy_loss)
+# assert isinstance(lazy_loss, LazyTensor), type(lazy_loss)
 network.zero_grad()
 lazy_loss.backward()
 

--- a/koila/lazy.py
+++ b/koila/lazy.py
@@ -713,7 +713,7 @@ SHAPE_OPS = MethodFunction[PrePassFunc](
         "l1_loss": prepasses.loss,
         "smooth_l1_loss": prepasses.loss,
         "mse_loss": prepasses.loss,
-        "cross_entropy": prepasses.loss,
+        # "cross_entropy": prepasses.loss,
         "binary_cross_entropy": prepasses.loss,
         "binary_cross_entropy_with_logits": prepasses.loss,
         "elu": prepasses.identity,


### PR DESCRIPTION
The label tensor has a different shape as the loss, if you use batch splitting on the loss.
Therefore I remove the cross cross_entropy from the lazy evaluation list.