### PR TITLE
Handle rendering of tensors gracefully.

### DIFF
--- a/src/aioway/_common/torch.py
+++ b/src/aioway/_common/torch.py
@@ -6,8 +6,6 @@ import numpy as np
 import tensordict as td
 import torch
 
-from aioway.fn.ctx import torch_disable_torch_func
-
 __all__ = ["tdict_rename", "tdict_all_equal", "replace_tensors", "find_nested_tensors"]
 
 
@@ -23,8 +21,16 @@ def tdict_all_equal(left: td.TensorDict, right: td.TensorDict, /):
     return eq.all()
 
 
-@torch_disable_torch_func
 def replace_tensors(
+    obj: object, replace: cabc.Callable[[torch.Tensor], object]
+) -> object:
+    from aioway.fn import disable_torch_function
+
+    with disable_torch_function():
+        return _replace_tensors(obj, replace)
+
+
+def _replace_tensors(
     obj: object, replace: cabc.Callable[[torch.Tensor], object]
 ) -> object:
     """
@@ -43,10 +49,10 @@ def replace_tensors(
         return obj
 
     if isinstance(obj, cabc.Sequence):
-        return [replace_tensors(elem, replace) for elem in obj]
+        return [_replace_tensors(elem, replace) for elem in obj]
 
     if isinstance(obj, cabc.Mapping):
-        return {key: replace_tensors(elem, replace) for key, elem in obj.items()}
+        return {key: _replace_tensors(elem, replace) for key, elem in obj.items()}
 
     return obj
 

--- a/src/aioway/_common/torch.py
+++ b/src/aioway/_common/torch.py
@@ -6,6 +6,8 @@ import numpy as np
 import tensordict as td
 import torch
 
+from aioway.fn.ctx import torch_disable_torch_func
+
 __all__ = ["tdict_rename", "tdict_all_equal", "replace_tensors", "find_nested_tensors"]
 
 
@@ -21,11 +23,17 @@ def tdict_all_equal(left: td.TensorDict, right: td.TensorDict, /):
     return eq.all()
 
 
+@torch_disable_torch_func
 def replace_tensors(
     obj: object, replace: cabc.Callable[[torch.Tensor], object]
 ) -> object:
     """
     Replace tensors whenever encountered with the given function.
+
+    This function has the `__torch_function__` disabled in the scope of the rendering,
+    because it can mess with attribute access, which oftentimes means that
+    this function fails also during debugging if `__torch_function__` is not disabled.
+    Caused by `.device` / `.shape` / `.dtype` calls, which is used in `replace_tensors`.
     """
 
     if isinstance(obj, torch.Tensor):

--- a/src/aioway/fn/__init__.py
+++ b/src/aioway/fn/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-from .fake import *
+from .ctx import *
 from .fate import *
 from .fn import *
 from .guards import *

--- a/src/aioway/fn/ctx.py
+++ b/src/aioway/fn/ctx.py
@@ -42,7 +42,6 @@ def to_fake_tensor(tensor: torch.Tensor) -> ft.FakeTensor:
     with torch_fake_mode() as mode:
         converter = mode.fake_tensor_converter
         return converter.from_real_tensor(mode, tensor)
-        converter.from_meta_and_device
 
 
 def to_fake_tensordict(tdict: td.TensorDict) -> td.TensorDict:

--- a/src/aioway/fn/ctx.py
+++ b/src/aioway/fn/ctx.py
@@ -21,6 +21,7 @@ __all__ = [
     "to_fake_tensordict",
     "enabled_fake_mode",
     "torch_real_mode",
+    "torch_disable_torch_func",
 ]
 
 LOGGER = logging.getLogger(__name__)
@@ -127,6 +128,19 @@ def _set_fake_mode_flag(to: bool):
         _fake_mode_is_active = before
 
 
+def torch_disable_torch_func[**P, T](func: cabc.Callable[P, T]) -> cabc.Callable[P, T]:
+    """
+    Disable `__torch_function__` mode, for the wrapped function.
+    """
+
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        with torch.DisableTorchFunction():
+            return func(*args, **kwargs)
+
+    _set_wrapper_func(wrapper, func)
+    return wrapper
+
+
 def torch_enable_fake_mode_func(to: bool, /):
     def decorator[**P, T](func: cabc.Callable[P, T]) -> cabc.Callable[P, T]:
         """
@@ -137,11 +151,16 @@ def torch_enable_fake_mode_func(to: bool, /):
             with torch_enable_fake_mode(to):
                 return func(*args, **kwargs)
 
-        wrapper.__qualname__ = func.__qualname__
-        wrapper.__name__ = func.__name__
-        wrapper.__module__ = func.__module__
-        wrapper.__doc__ = func.__doc__
-
+        _set_wrapper_func(wrapper, func)
         return wrapper
 
     return decorator
+
+
+def _set_wrapper_func[**P, T](
+    wrapper: cabc.Callable[P, T], func: cabc.Callable[P, T]
+) -> None:
+    wrapper.__qualname__ = func.__qualname__
+    wrapper.__name__ = func.__name__
+    wrapper.__module__ = func.__module__
+    wrapper.__doc__ = func.__doc__

--- a/src/aioway/fn/ctx.py
+++ b/src/aioway/fn/ctx.py
@@ -21,7 +21,8 @@ __all__ = [
     "to_fake_tensordict",
     "enabled_fake_mode",
     "torch_real_mode",
-    "torch_disable_torch_func",
+    "disable_torch_function",
+    "disable_torch_func_decorator",
 ]
 
 LOGGER = logging.getLogger(__name__)
@@ -127,13 +128,25 @@ def _set_fake_mode_flag(to: bool):
         _fake_mode_is_active = before
 
 
-def torch_disable_torch_func[**P, T](func: cabc.Callable[P, T]) -> cabc.Callable[P, T]:
+@ctxl.contextmanager
+def disable_torch_function():
+    """
+    Disable `__torch_function__` mode, for the given scope.
+    """
+
+    with torch.DisableTorchFunction():
+        yield
+
+
+def disable_torch_func_decorator[**P, T](
+    func: cabc.Callable[P, T],
+) -> cabc.Callable[P, T]:
     """
     Disable `__torch_function__` mode, for the wrapped function.
     """
 
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-        with torch.DisableTorchFunction():
+        with disable_torch_function():
             return func(*args, **kwargs)
 
     _set_wrapper_func(wrapper, func)

--- a/src/aioway/fn/fake.py
+++ b/src/aioway/fn/fake.py
@@ -41,6 +41,7 @@ def to_fake_tensor(tensor: torch.Tensor) -> ft.FakeTensor:
     with torch_fake_mode() as mode:
         converter = mode.fake_tensor_converter
         return converter.from_real_tensor(mode, tensor)
+        converter.from_meta_and_device
 
 
 def to_fake_tensordict(tdict: td.TensorDict) -> td.TensorDict:

--- a/src/aioway/fn/fate/fate.py
+++ b/src/aioway/fn/fate/fate.py
@@ -135,10 +135,6 @@ class FateFn(HasParam):
         return self.original.func
 
     @property
-    def types(self):
-        return self.original.types
-
-    @property
     def args(self):
         return self.original.args
 

--- a/src/aioway/fn/modes.py
+++ b/src/aioway/fn/modes.py
@@ -63,11 +63,10 @@ class _TThunkBaseFn[T: _TorchCallable](HasParam, abc.ABC):
 
     __match_args__ = "func", "types", "args", "kwargs"
 
+    _: dcls.KW_ONLY
+
     func: T
     "The `torch.*`, `Tensor.*` functions."
-
-    types: tuple[type, ...]
-    "The types of the arguments."
 
     args: tuple[typing.Any, ...]
     "The positional args."
@@ -84,12 +83,6 @@ class _TThunkBaseFn[T: _TorchCallable](HasParam, abc.ABC):
 
         if not isinstance(self.kwargs, dict):
             raise TypeError(f"{self.kwargs=} is not a dict.")
-
-    def __iter__(self) -> cabc.Iterator[typing.Any]:
-        yield self.func
-        yield self.types
-        yield self.args
-        yield self.kwargs
 
     @typing.override
     @typing.no_type_check
@@ -109,6 +102,9 @@ class TFunctionFn(_TThunkBaseFn[cabc.Callable[..., typing.Any]]):
 
     The `func` here are `torch.*` or `torch.Tensor` operators.
     """
+
+    types: tuple[type, ...]
+    "The types of the arguments."
 
     def __hash__(self) -> int:
         return id(self)
@@ -209,7 +205,7 @@ class TFunctionMode(overrides.TorchFunctionMode, TMode[TFunctionFn], abc.ABC):
     @typing.override
     def __torch_function__(self, func, types, args=(), kwargs=None):
         kwargs = kwargs or {}
-        thunk = TFunctionFn(func, types, args, kwargs)
+        thunk = TFunctionFn(func=func, types=types, args=args, kwargs=kwargs)
         return self(thunk)
 
     @staticmethod
@@ -243,7 +239,11 @@ class TDispatchMode(pyd.TorchDispatchMode, TMode[TDispatchFn], abc.ABC):
     @typing.override
     def __torch_dispatch__(self, func, types, args=(), kwargs=None) -> typing.Any:
         kwargs = kwargs or {}
-        thunk = TDispatchFn(func, types, args, kwargs)
+
+        if not all(issubclass(t, torch.Tensor) for t in types):
+            raise AssertionError(f"Not all {types=} are subclasses of `torch.Tensor`.")
+
+        thunk = TDispatchFn(func=func, args=args, kwargs=kwargs)
         return self(thunk)
 
     @staticmethod

--- a/src/aioway/fn/modes.py
+++ b/src/aioway/fn/modes.py
@@ -183,8 +183,10 @@ def _render_tensor_as_attr(
     func: str, args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
 ):
     # `Attr`s are better for display than `torch.Tensor`s.
+
     args = replace_tensors(args, attr)
     kwargs = replace_tensors(kwargs, attr)
+
     return render_fcall(func, *args, **kwargs)
 
 

--- a/src/aioway/fn/routers.py
+++ b/src/aioway/fn/routers.py
@@ -8,7 +8,7 @@ from collections import abc as cabc
 
 import torch
 
-from .fake import enabled_fake_mode, torch_fake_mode
+from .ctx import enabled_fake_mode, torch_fake_mode
 from .fate import FateFn, find_fate
 from .guards import is_aten_op, is_prim_op, is_torchcodec_op, is_torchvision_op
 from .modes import TDispatchFn, TDispatchMode, TFunctionFn, TFunctionMode
@@ -49,6 +49,12 @@ def only_route_in_fake(thunk: TDispatchFn):
 
 def no_route(thunk: TDispatchFn):
     return NotImplemented
+
+
+@dcls.dataclass
+class EnsureOnce(TDispatchMode):
+    def __call__(self, thunk: TDispatchFn) -> torch.Tensor:
+        return thunk.do()
 
 
 @dcls.dataclass

--- a/src/aioway/fn/tracking.py
+++ b/src/aioway/fn/tracking.py
@@ -36,9 +36,7 @@ def print_torch_function(thunk: TFunctionFn) -> torch.Tensor:
     Print the function calls.
     """
 
-    result = thunk.do()
-    rich.print(thunk)
-    return result
+    return _print_torch_thunk(thunk)
 
 
 @TDispatchMode.register
@@ -47,8 +45,13 @@ def print_torch_dispatch(thunk: TDispatchFn) -> torch.Tensor:
     Print the dispatcher.
     """
 
+    return _print_torch_thunk(thunk)
+
+
+def _print_torch_thunk(thunk: TFunctionFn | TDispatchFn) -> torch.Tensor:
+    rich.print(thunk, end=" ", flush=True)
     result = thunk.do()
-    rich.print(thunk)
+    rich.print(f"-> {result}")
     return result
 
 

--- a/src/aioway/fn/tracking.py
+++ b/src/aioway/fn/tracking.py
@@ -7,7 +7,6 @@ import dataclasses as dcls
 import logging
 import typing
 
-import rich
 import torch
 
 from aioway._common import Stack

--- a/src/aioway/fn/tracking.py
+++ b/src/aioway/fn/tracking.py
@@ -49,9 +49,9 @@ def print_torch_dispatch(thunk: TDispatchFn) -> torch.Tensor:
 
 
 def _print_torch_thunk(thunk: TFunctionFn | TDispatchFn) -> torch.Tensor:
-    rich.print(thunk, end=" ", flush=True)
+    print("invoke", thunk)
     result = thunk.do()
-    rich.print(f"-> {result}")
+    print("return", thunk, "->", result)
     return result
 
 

--- a/src/aioway/schemas/attrs.py
+++ b/src/aioway/schemas/attrs.py
@@ -144,6 +144,15 @@ class AttrTensor:
     The attached info (most of the info can be derived from the tensor, but some cannot).
     """
 
+    @classmethod
+    def from_tensor_info(cls, tensor: torch.Tensor, *infos: Info) -> typing.Self:
+        """
+        Auto determine some fields in `Attr` and create an `AttrTensor`.
+        """
+
+        attr = Attr.from_tensor(tensor, *infos)
+        return cls(tensor=tensor, attr=attr)
+
 
 class AttrDict(typing.TypedDict):
     device: DeviceLike


### PR DESCRIPTION
Handle tensor rendering gracefully by disabling `__torch_funciton__` compmletely during rendering.

Fix #208