### PR TITLE
Image loading with pillow.

### DIFF
--- a/src/aioway/_common/decomps.py
+++ b/src/aioway/_common/decomps.py
@@ -61,7 +61,7 @@ def _replace_tensors(
     if isinstance(obj, torch.Tensor):
         return replace(obj)
 
-    if isinstance(obj, np.ndarray | pd.DataFrame):
+    if isinstance(obj, DECOMP_BLOCK_TYPES):
         return obj
 
     if isinstance(obj, cabc.Sequence):

--- a/src/aioway/_common/decomps.py
+++ b/src/aioway/_common/decomps.py
@@ -3,6 +3,7 @@
 "Decomposing objects for inspection and debugging."
 
 import dataclasses as dcls
+import functools
 import typing
 from collections import abc as cabc
 
@@ -85,10 +86,13 @@ class DecomposeCheck(typing.Protocol):
 class DecompStep(typing.Protocol):
     def handles(self, obj, /) -> bool: ...
     def decompose(self, obj, /) -> cabc.Iterable[typing.Any]: ...
+@functools.cache
+def _ids_of(seq: cabc.Sequence[typing.Any]) -> list[int]:
+    return [id(item) for item in seq]
 
 
 def default_stop_decompose(obj: object) -> bool:
-    return obj in DECOMP_BLOCK_ITEMS or isinstance(obj, DECOMP_BLOCK_TYPES)
+    return id(obj) in _ids_of(DECOMP_BLOCK_ITEMS) or isinstance(obj, DECOMP_BLOCK_TYPES)
 
 
 class DecompSeq:

--- a/src/aioway/_common/renders.py
+++ b/src/aioway/_common/renders.py
@@ -2,17 +2,21 @@
 
 "Print the objects to the terminal in a nice way."
 
+import types
 import typing
 from collections import abc as cabc
 
 import rich
+import torch
 from rich import syntax, tree
+from torch import _ops
 
 __all__ = [
     "render_fcall",
     "subclass_tree",
     "print_subclass_tree",
     "render_class_syntax",
+    "render_func_name",
 ]
 
 type FunctionLike = str | cabc.Callable[..., typing.Any]
@@ -72,3 +76,32 @@ def _subclass_tree(
     for sub_cls in cls.__subclasses__():
         sub_tree = tree.add(render(sub_cls))
         _subclass_tree(sub_cls, sub_tree, seen=seen, render=render)
+
+
+def render_func_name(func: cabc.Callable[..., typing.Any]) -> str:
+    name = func.__name__
+
+    # Only descriptors use `__get__`, and we render the descriptor itself.
+    if name == "__get__":
+        assert isinstance(func, types.MethodType | types.MethodWrapperType), type(func)
+        return repr(func.__self__)
+
+    # It seems that there isn't an attribute that expose the name of the `OpOverload`,
+    # so here we combine `namespace` (aten, prim, ...) and `__name__` (packet.type).
+    if isinstance(func, _ops.OpOverload):
+        return f"torch.ops.{func.namespace}.{name}"
+
+    # Just converting to `str` works.
+    if isinstance(func, _ops.OpOverloadPacket):
+        return f"torch.ops.{func!s}"
+
+    # If it's `torch.*`.
+    if getattr(torch, name, None) is func:
+        return f"torch.{name}"
+
+    # If it's `torch.Tensor.*`.
+    if getattr(torch.Tensor, name, None) is func:
+        return f"torch.Tensor.{name}"
+
+    # Don't know what this is. Just use `__qualname__`.
+    return func.__qualname__

--- a/src/aioway/fn/modes.py
+++ b/src/aioway/fn/modes.py
@@ -3,7 +3,6 @@
 "Torch function/dispatch modes, corresponding to `__torch_function__`/`__torch_dispatch__`."
 
 import abc
-import contextlib as ctxl
 import dataclasses as dcls
 import types
 import typing
@@ -189,13 +188,7 @@ def _render_tensor_short(
     return render_fcall(func, *args, **kwargs)
 
 
-class TMode[T](typing.Protocol):
-    @abc.abstractmethod
-    def __call__(self, thunk: T, /) -> torch.Tensor:
-        raise NotImplementedError
-
-
-class TFunctionMode(overrides.TorchFunctionMode, TMode[TFunctionFn], abc.ABC):
+class TFunctionMode(overrides.TorchFunctionMode, abc.ABC):
     """
     `TorchFunctionMode` is the adaptor for `torch.overrides.TorchFunctionMode`.
     """
@@ -211,25 +204,8 @@ class TFunctionMode(overrides.TorchFunctionMode, TMode[TFunctionFn], abc.ABC):
         thunk = TFunctionFn(func=func, types=types, args=args, kwargs=kwargs)
         return self(thunk)
 
-    @staticmethod
-    def register(
-        f: TMode[TFunctionFn],
-    ) -> cabc.Callable[[], typing.ContextManager[None]]:
 
-        class _FuncTorchFunctionMode(TFunctionMode):
-            @typing.override
-            def __call__(self, t: TFunctionFn) -> typing.Any:
-                return f(t)
-
-        @ctxl.contextmanager
-        def ctx_man():
-            with _FuncTorchFunctionMode():
-                yield
-
-        return ctx_man
-
-
-class TDispatchMode(pyd.TorchDispatchMode, TMode[TDispatchFn], abc.ABC):
+class TDispatchMode(pyd.TorchDispatchMode, abc.ABC):
     """
     `TorchDispatchMode` is the adaptor for `torch.data._python_dispatch.TorchDispatchMode`.
     """
@@ -248,22 +224,6 @@ class TDispatchMode(pyd.TorchDispatchMode, TMode[TDispatchFn], abc.ABC):
 
         thunk = TDispatchFn(func=func, args=args, kwargs=kwargs)
         return self(thunk)
-
-    @staticmethod
-    def register(
-        f: TMode[TDispatchFn],
-    ) -> cabc.Callable[[], typing.ContextManager[None]]:
-        class _FuncTorchDispatchMode(TDispatchMode):
-            @typing.override
-            def __call__(self, t: TDispatchFn, /) -> torch.Tensor:
-                return f(t)
-
-        @ctxl.contextmanager
-        def ctx_man():
-            with _FuncTorchDispatchMode():
-                yield
-
-        return ctx_man
 
 
 @typing.final

--- a/src/aioway/fn/modes.py
+++ b/src/aioway/fn/modes.py
@@ -4,7 +4,6 @@
 
 import abc
 import dataclasses as dcls
-import types
 import typing
 from collections import abc as cabc
 
@@ -19,8 +18,11 @@ from aioway._common import (
     is_aten_op,
     is_prim_op,
     render_fcall,
+    render_func_name,
+    replace_tensors,
 )
 from aioway.fate import Fate, find_fate
+from aioway.schemas import attr
 
 from .fn import Fn
 
@@ -143,47 +145,20 @@ def _render_function_body(
     args: tuple[typing.Any, ...],
     kwargs: dict[str, typing.Any],
 ) -> str:
-    func_name = _render_func_name(func)
-    return _render_tensor_short(prefix + "::" + func_name, args, kwargs)
-
-
-def _render_func_name(func: cabc.Callable[..., typing.Any]) -> str:
-    name = func.__name__
-
-    # Only descriptors use `__get__`, and we render the descriptor itself.
-    if name == "__get__":
-        assert isinstance(func, types.MethodType | types.MethodWrapperType), type(func)
-        return repr(func.__self__)
-
-    # It seems that there isn't an attribute that expose the name of the `OpOverload`,
-    # so here we combine `namespace` (aten, prim, ...) and `__name__` (packet.type).
-    if isinstance(func, _ops.OpOverload):
-        return f"torch.ops.{func.namespace}.{name}"
-
-    # Just converting to `str` works.
-    if isinstance(func, _ops.OpOverloadPacket):
-        return f"torch.ops.{func!s}"
-
-    # If it's `torch.*`.
-    if getattr(torch, name, None) is func:
-        return f"torch.{name}"
-
-    # If it's `torch.Tensor.*`.
-    if getattr(torch.Tensor, name, None) is func:
-        return f"torch.Tensor.{name}"
-
-    # Don't know what this is. Just use `__qualname__`.
-    return func.__qualname__
+    func_name = render_func_name(func)
+    return render_tensor_func_short(prefix + "::" + func_name, args, kwargs)
 
 
 @typing.no_type_check
-def _render_tensor_short(
-    func: str, args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
-):
+def replace_tensors_with_attr[T](obj: T) -> T:
+    return replace_tensors(obj, attr)
+
+
+def render_tensor_func_short(func: str, args, kwargs) -> str:
     # `Attr`s are better for display than `torch.Tensor`s.
 
-    # args = replace_tensors(args, attr)
-    # kwargs = replace_tensors(kwargs, attr)
+    args = replace_tensors_with_attr(args)
+    kwargs = replace_tensors_with_attr(kwargs)
 
     return render_fcall(func, *args, **kwargs)
 

--- a/src/aioway/fn/tracking.py
+++ b/src/aioway/fn/tracking.py
@@ -5,7 +5,7 @@
 import collections
 import dataclasses as dcls
 import logging
-import typing
+import typing, itertools
 
 import rich
 import torch
@@ -157,7 +157,9 @@ class FnHistory[T: FateFn | TFunctionFn | TDispatchFn]:
     )
     "The mapping from input to the thunk containing that input."
 
-    output_to_thunk: dict[torch.Tensor, T] = dcls.field(default_factory=dict)
+    output_to_thunk_list: dict[torch.Tensor, list[T]] = dcls.field(
+        default_factory=lambda: collections.defaultdict(list)
+    )
     "The mapping from output to thunk that generates it."
 
     def __len__(self) -> int:
@@ -180,8 +182,7 @@ class FnHistory[T: FateFn | TFunctionFn | TDispatchFn]:
         # `__torch_function__` doesn't always return `torch.Tensor` actually!
         if isinstance(output, torch.Tensor):
             # Update output.
-            assert output not in self.output_to_thunk
-            self.output_to_thunk[output] = item
+            self.output_to_thunk_list[output].append(item)
 
         # Update input.
         for input_tensor in item.tensors():
@@ -193,14 +194,14 @@ class FnHistory[T: FateFn | TFunctionFn | TDispatchFn]:
         graph: nx.DiGraph[T] = nx.DiGraph()
         graph.add_nodes_from(hist.fn for hist in self.history)
 
-        input_thunks = self.input_to_thunk_list
-        output_thunks = self.output_to_thunk
+        ins = self.input_to_thunk_list
+        outs = self.output_to_thunk_list
 
-        tensors = set(input_thunks.keys()).intersection(output_thunks.keys())
+        tensors = set(ins.keys()).intersection(outs.keys())
 
         for tensor in tensors:
-            for target_thunk in input_thunks[tensor]:
-                _ = graph.add_edge(self.output_to_thunk[tensor], target_thunk)
+            for out_thunk, in_thunk in itertools.product(outs[tensor], ins[tensor]):
+                _ = graph.add_edge(out_thunk, in_thunk)
 
         return graph
 
@@ -223,4 +224,4 @@ class FnHistory[T: FateFn | TFunctionFn | TDispatchFn]:
         return sum(attr(param).memory() for param in self.parameters(filter_tensor_off))
 
     def find_fn(self, tensor: torch.Tensor):
-        return self.output_to_thunk[tensor]
+        return self.output_to_thunk_list[tensor]

--- a/src/aioway/fn/tracking.py
+++ b/src/aioway/fn/tracking.py
@@ -13,7 +13,14 @@ import torch
 from aioway._common import Stack, TensorFilter, filter_tensor_off, is_leaf_has_grad
 from aioway.schemas import attr
 
-from .modes import FateFn, TDispatchFn, TDispatchMode, TFunctionFn, TFunctionMode
+from .modes import (
+    FateFn,
+    TDispatchFn,
+    TDispatchMode,
+    TFunctionFn,
+    TFunctionMode,
+    replace_tensors_with_attr,
+)
 
 __all__ = [
     "PrintTorchFunction",
@@ -52,7 +59,7 @@ class _ThunkPrinter:
     def __call__(self, thunk: TFunctionFn | TDispatchFn) -> torch.Tensor:
         self.print("invoke", thunk)
         result = thunk.do()
-        self.print("return", thunk, "->", result)
+        self.print("return", thunk, "->", replace_tensors_with_attr(result))
         return result
 
     @property

--- a/src/aioway/fn/tracking.py
+++ b/src/aioway/fn/tracking.py
@@ -7,6 +7,7 @@ import dataclasses as dcls
 import logging
 import typing
 
+import rich
 import torch
 
 from aioway._common import Stack, TensorFilter, filter_tensor_off, is_leaf_has_grad
@@ -15,8 +16,8 @@ from aioway.schemas import attr
 from .modes import FateFn, TDispatchFn, TDispatchMode, TFunctionFn, TFunctionMode
 
 __all__ = [
-    "print_torch_function",
-    "print_torch_dispatch",
+    "PrintTorchFunction",
+    "PrintTorchDispatch",
     "LogTorchFunction",
     "LogTorchDispatch",
     "TorchFunctionStack",
@@ -27,29 +28,36 @@ __all__ = [
 LOGGER = logging.getLogger(__name__)
 
 
-@TFunctionMode.register
-def print_torch_function(thunk: TFunctionFn) -> torch.Tensor:
-    """
-    Print the function calls.
-    """
+class PrintTorchFunction(TFunctionMode):
+    rich: bool = False
 
-    return _print_torch_thunk(thunk)
-
-
-@TDispatchMode.register
-def print_torch_dispatch(thunk: TDispatchFn) -> torch.Tensor:
-    """
-    Print the dispatcher.
-    """
-
-    return _print_torch_thunk(thunk)
+    @typing.override
+    def __call__(self, thunk: TFunctionFn, /) -> torch.Tensor:
+        return _ThunkPrinter(rich=self.rich)(thunk)
 
 
-def _print_torch_thunk(thunk: TFunctionFn | TDispatchFn) -> torch.Tensor:
-    print("invoke", thunk)
-    result = thunk.do()
-    print("return", thunk, "->", result)
-    return result
+class PrintTorchDispatch(TDispatchMode):
+    rich: bool = False
+
+    @typing.override
+    def __call__(self, thunk: TDispatchFn, /) -> torch.Tensor:
+        return _ThunkPrinter(rich=self.rich)(thunk)
+
+
+@dcls.dataclass(frozen=True)
+class _ThunkPrinter:
+    rich: bool
+    "Use rich for printing."
+
+    def __call__(self, thunk: TFunctionFn | TDispatchFn) -> torch.Tensor:
+        self.print("invoke", thunk)
+        result = thunk.do()
+        self.print("return", thunk, "->", result)
+        return result
+
+    @property
+    def print(self):
+        return rich.print if self.rich else print
 
 
 @dcls.dataclass

--- a/src/aioway/io/images.py
+++ b/src/aioway/io/images.py
@@ -98,7 +98,7 @@ class TvioImageLoader:
     But, it doesn't work in fake mode, so calling it always loads the tensor into memory.
     """
 
-    norm: bool = True
+    norm: bool = False
     "If `True`, normalize the `uint8` tensor to 0-1 `float` tensor."
 
     def __call__(self, fname: str | pathlib.Path):

--- a/src/aioway/io/images.py
+++ b/src/aioway/io/images.py
@@ -1,36 +1,121 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-import os
+import abc
+import dataclasses as dcls
 import pathlib
+import typing
 
+import torch
+from PIL import Image as image
 from torchvision import io as vio
+from torchvision.transforms import v2 as tt
 
-from aioway.fn import torch_enable_fake_mode_func
+from aioway.fn import enabled_fake_mode, torch_enable_fake_mode_func
+from aioway.schemas import attr
 
-__all__ = ["read_image_from_path_torch", "read_image_torch_normalized"]
-
-
-@torch_enable_fake_mode_func(False)
-def read_image_from_path_torch(fname: os.PathLike[str]):
-    fname_path = pathlib.Path(fname)
-    fname_str = str(fname_path)
-
-    match fname_path.suffix:
-        # According to torch's documentation,
-        # weirdly the `decode_image` function only decode these files.
-        case ".jpg" | ".png" | ".gif" | ".webp":
-            return vio.decode_image(fname_str)
-
-        # This requires installing extra dependencies, do this later.
-        # https://docs.pytorch.org/vision/main/generated/torchvision.io.decode_image.html
-        case ".avif" | ".heic":
-            raise ValueError(
-                "AVIF or HEIC requires extra dependencies, not supported yet!"
-            )
-
-        case _:
-            raise ValueError(f"Does not support {fname_path.suffix} files.")
+__all__ = ["read_image_from_path"]
 
 
-def read_image_torch_normalized(fname: os.PathLike[str]):
-    return read_image_from_path_torch(fname).float() / 255
+@dcls.dataclass
+class ImageLoader(abc.ABC):
+    "The image loader API. Converts from a file name `fname` to a tensor."
+
+    @abc.abstractmethod
+    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        raise NotImplementedError
+
+
+@dcls.dataclass
+class ComposedImageLoader(ImageLoader):
+    """
+    First load the image, then use `tt.Transform` to load it.
+
+    It seems that `tt.Transform` uses mostly normal `torch.aten` operations,
+    so we should have a good chance of making it work with fake mode.
+    """
+
+    loader: ImageLoader
+    "The image loader."
+
+    transform: tt.Transform = tt.Compose([])
+    "This is a series of `torchvision` `Transform`."
+
+    @typing.override
+    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        tensor = self.loader(fname)
+        return self.transform(tensor)
+
+
+@dcls.dataclass
+class PillowImageLoader(ImageLoader):
+    """
+    This is the pillow image loader + torchvision compose.
+    """
+
+    transform: tt.Transform = tt.PILToTensor()
+    "The transform to use to convert the pillow image to a tensor."
+
+    @typing.override
+    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        img = image.open(fname)
+        return self.transform(img)
+
+
+@dcls.dataclass
+class FakePillowImageLoader(ImageLoader):
+    def __post_init__(self):
+        if not enabled_fake_mode():
+            raise RuntimeError(f"{type(self)} only works in fake mode!")
+
+    @typing.override
+    @torch_enable_fake_mode_func(True)
+    def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        img = image.open(fname)
+
+        return attr(
+            {
+                "shape": [len(img.mode), img.width, img.height],
+                "device": "cpu",
+                "dtype": "float32",
+            }
+        ).to_tensor()
+
+
+@dcls.dataclass
+class TvioImageLoader:
+    """
+    The loader backed by `torchvision.io`. It should be faster than the PIL route.
+
+    But, it doesn't work in fake mode, so calling it always loads the tensor into memory.
+    """
+
+    norm: bool = True
+    "If `True`, normalize the `uint8` tensor to 0-1 `float` tensor."
+
+    def __call__(self, fname: str | pathlib.Path):
+        reader = self._read_normalized if self.norm else self._read_image
+        return reader(fname)
+
+    @torch_enable_fake_mode_func(False)
+    def _read_image(self, fname: str | pathlib.Path):
+        fname_path = pathlib.Path(fname)
+        fname_str = str(fname_path)
+
+        match fname_path.suffix:
+            # According to torch's documentation,
+            # weirdly the `decode_image` function only decode these files.
+            case ".jpg" | ".png" | ".gif" | ".webp":
+                return vio.decode_image(fname_str)
+
+            # This requires installing extra dependencies, do this later.
+            # https://docs.pytorch.org/vision/main/generated/torchvision.io.decode_image.html
+            case ".avif" | ".heic":
+                raise ValueError(
+                    "AVIF or HEIC requires extra dependencies, not supported yet!"
+                )
+
+            case _:
+                raise ValueError(f"Does not support {fname_path.suffix} files.")
+
+    def _read_normalized(self, fname: str | pathlib.Path):
+        return self._read_image(fname).float() / 255

--- a/src/aioway/io/images.py
+++ b/src/aioway/io/images.py
@@ -7,11 +7,11 @@ from torchvision import io as vio
 
 from aioway.fn import torch_enable_fake_mode_func
 
-__all__ = ["read_image_from_path", "read_image_normalized"]
+__all__ = ["read_image_from_path_torch", "read_image_torch_normalized"]
 
 
 @torch_enable_fake_mode_func(False)
-def read_image_from_path(fname: os.PathLike[str]):
+def read_image_from_path_torch(fname: os.PathLike[str]):
     fname_path = pathlib.Path(fname)
     fname_str = str(fname_path)
 
@@ -32,5 +32,5 @@ def read_image_from_path(fname: os.PathLike[str]):
             raise ValueError(f"Does not support {fname_path.suffix} files.")
 
 
-def read_image_normalized(fname: os.PathLike[str]):
-    return read_image_from_path(fname).float() / 255
+def read_image_torch_normalized(fname: os.PathLike[str]):
+    return read_image_from_path_torch(fname).float() / 255

--- a/src/aioway/io/images.py
+++ b/src/aioway/io/images.py
@@ -13,7 +13,13 @@ from torchvision.transforms import v2 as tt
 from aioway.fn import enabled_fake_mode, torch_enable_fake_mode_func
 from aioway.schemas import attr
 
-__all__ = ["read_image_from_path"]
+__all__ = [
+    "ImageLoader",
+    "ComposedImageLoader",
+    "PillowImageLoader",
+    "FakePillowImageLoader",
+    "TvioImageLoader",
+]
 
 
 @dcls.dataclass
@@ -37,8 +43,11 @@ class ComposedImageLoader(ImageLoader):
     loader: ImageLoader
     "The image loader."
 
-    transform: tt.Transform = tt.Compose([])
-    "This is a series of `torchvision` `Transform`."
+    transform: tt.Transform = tt.Lambda(lambda t: t)
+    """
+    This is a series of `torchvision` `Transform`.
+    Default to null op (a lambda because compose cannot be empty).
+    """
 
     @typing.override
     def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:

--- a/src/aioway/io/images.py
+++ b/src/aioway/io/images.py
@@ -72,22 +72,26 @@ class PillowImageLoader(ImageLoader):
 
 @dcls.dataclass
 class FakePillowImageLoader(ImageLoader):
-    def __post_init__(self):
-        if not enabled_fake_mode():
-            raise RuntimeError(f"{type(self)} only works in fake mode!")
-
     @typing.override
     @torch_enable_fake_mode_func(True)
     def __call__(self, fname: str | pathlib.Path, /) -> torch.Tensor:
+        if not enabled_fake_mode():
+            raise RuntimeError(f"{type(self)} only works in fake mode!")
+
         img = image.open(fname)
 
-        return attr(
-            {
-                "shape": [len(img.mode), img.width, img.height],
-                "device": "cpu",
-                "dtype": "float32",
-            }
-        ).to_tensor()
+        # Convert to `uint8` as a hack, because we don't support it in our dtypes.
+        return (
+            attr(
+                {
+                    "shape": [len(img.mode), img.width, img.height],
+                    "device": "cpu",
+                    "dtype": "int",
+                }
+            )
+            .to_tensor()
+            .to(torch.uint8)
+        )
 
 
 @dcls.dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import torch
 from numpy import random as npr
 from rich import traceback
 
+from aioway.fn import fake_fn, track_fn
+
 from .fake import batch_sizes, cpu_and_maybe_cuda
 
 
@@ -46,3 +48,20 @@ def data_size() -> int:
 @pytest.fixture(params=batch_sizes())
 def batch_size(request: pytest.FixtureRequest) -> int:
     return request.param
+
+
+@pytest.fixture
+def fake_mode():
+    with fake_fn():
+        yield
+
+
+@pytest.fixture
+def real_mode():
+    with track_fn():
+        yield
+
+
+@pytest.fixture(params=[fake_mode.name, real_mode.name])
+def maybe_fake_mode(request: pytest.FixtureRequest):
+    yield request.getfixturevalue(request.param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
+import pathlib
 import random
 
 import pytest
@@ -8,6 +9,11 @@ from numpy import random as npr
 from rich import traceback
 
 from .fake import batch_sizes, cpu_and_maybe_cuda
+
+
+@pytest.fixture(scope="module")
+def media():
+    return (pathlib.Path(__file__).parent.parent / "media").resolve()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/fn/test_modes.py
+++ b/tests/fn/test_modes.py
@@ -10,6 +10,7 @@ from aioway.fn import (
     torch_fake_mode,
     track_fn,
 )
+from aioway.fn.ctx import enabled_fake_mode
 
 
 @pytest.fixture
@@ -20,6 +21,14 @@ def a():
 @pytest.fixture
 def b():
     return torch.randn(5)
+
+
+def test_fake_mode(fake_mode):
+    assert enabled_fake_mode()
+
+
+def test_real_mode(real_mode):
+    assert not enabled_fake_mode()
 
 
 @pytest.fixture

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -4,8 +4,6 @@ import pathlib
 
 import pytest
 
-from aioway.fn import fake_fn, track_fn
-
 
 @pytest.fixture
 def example_jpg(media: pathlib.Path):
@@ -47,9 +45,3 @@ def example_audio(request: pytest.FixtureRequest):
 @pytest.fixture(params=[example_mp4.name])
 def example_video(request: pytest.FixtureRequest):
     return request.getfixturevalue(request.param)
-
-
-@pytest.fixture(params=[fake_fn, track_fn])
-def maybe_fake_mode(request: pytest.FixtureRequest):
-    with request.param() as hists:
-        yield hists

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -3,25 +3,8 @@
 import pathlib
 
 import pytest
-import torch
 
 from aioway.fn import fake_fn, track_fn
-from aioway.io import (
-    read_audio_from_path,
-    read_image_from_path,
-    read_video_from_path,
-)
-
-
-@pytest.fixture(scope="session")
-def media():
-    return pathlib.Path(__file__).parent.parent / "media"
-
-
-@pytest.fixture(params=[fake_fn, track_fn], autouse=True)
-def maybe_fake_mode(request: pytest.FixtureRequest):
-    with request.param() as hists:
-        yield hists
 
 
 @pytest.fixture
@@ -66,26 +49,7 @@ def example_video(request: pytest.FixtureRequest):
     return request.getfixturevalue(request.param)
 
 
-def test_media_exits(media: pathlib.Path):
-    assert media.exists()
-    assert media.is_dir()
-
-
-def test_example_file_exists(example_file: pathlib.Path):
-    assert example_file.exists()
-    assert example_file.is_file()
-
-
-def test_read_img(example_image: pathlib.Path):
-    img = read_image_from_path(example_image)
-    assert isinstance(img, torch.Tensor)
-
-
-def test_read_audio(example_audio: pathlib.Path):
-    audio = read_audio_from_path(example_audio)
-    assert isinstance(audio.data, torch.Tensor)
-
-
-def test_read_video(example_video: pathlib.Path):
-    video = read_video_from_path(example_video)
-    assert isinstance(video, torch.Tensor)
+@pytest.fixture(params=[fake_fn, track_fn])
+def maybe_fake_mode(request: pytest.FixtureRequest):
+    with request.param() as hists:
+        yield hists

--- a/tests/io/test_images.py
+++ b/tests/io/test_images.py
@@ -1,0 +1,35 @@
+# Copyright (c) AIoWay Authors - All Rights Reserved
+
+import pathlib
+
+import pytest
+import torch
+
+from aioway.io import (
+    ImageLoader,
+    PillowImageLoader,
+    TvioImageLoader,
+)
+
+
+@pytest.fixture
+def torchvision_io_loader():
+    return TvioImageLoader()
+
+
+@pytest.fixture
+def pillow_image_loader():
+    return PillowImageLoader()
+
+
+@pytest.fixture(params=[torchvision_io_loader.name, pillow_image_loader.name])
+def image_loader(request: pytest.FixtureRequest):
+    return request.getfixturevalue(request.param)
+
+
+def test_read_image(
+    example_image: pathlib.Path, image_loader: ImageLoader, maybe_fake_mode
+):
+    image = image_loader(example_image)
+    assert isinstance(image.data, torch.Tensor)
+    assert image.dtype == torch.uint8

--- a/tests/io/test_images.py
+++ b/tests/io/test_images.py
@@ -5,11 +5,13 @@ import pathlib
 import pytest
 import torch
 
+from aioway.fn.ctx import is_fake_tensor
 from aioway.io import (
     ImageLoader,
     PillowImageLoader,
     TvioImageLoader,
 )
+from aioway.io.images import FakePillowImageLoader
 
 
 @pytest.fixture
@@ -27,9 +29,23 @@ def image_loader(request: pytest.FixtureRequest):
     return request.getfixturevalue(request.param)
 
 
+@pytest.fixture
+def fake_pillow_image_loader():
+    return FakePillowImageLoader()
+
+
 def test_read_image(
     example_image: pathlib.Path, image_loader: ImageLoader, maybe_fake_mode
 ):
     image = image_loader(example_image)
-    assert isinstance(image.data, torch.Tensor)
+    assert isinstance(image, torch.Tensor)
+    assert image.dtype == torch.uint8
+
+
+def test_read_image_fake(
+    example_image: pathlib.Path, fake_pillow_image_loader: ImageLoader, fake_mode
+):
+    image = fake_pillow_image_loader(example_image)
+    assert isinstance(image, torch.Tensor)
+    assert is_fake_tensor(image)
     assert image.dtype == torch.uint8

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -1,0 +1,27 @@
+# Copyright (c) AIoWay Authors - All Rights Reserved
+
+import pathlib
+
+import torch
+
+from aioway.io import read_audio_from_path, read_video_from_path
+
+
+def test_media_exits(media: pathlib.Path):
+    assert media.exists()
+    assert media.is_dir()
+
+
+def test_example_file_exists(example_file: pathlib.Path):
+    assert example_file.exists()
+    assert example_file.is_file()
+
+
+def test_read_audio(example_audio: pathlib.Path, maybe_fake_mode):
+    audio = read_audio_from_path(example_audio)
+    assert isinstance(audio.data, torch.Tensor)
+
+
+def test_read_video(example_video: pathlib.Path, maybe_fake_mode):
+    video = read_video_from_path(example_video)
+    assert isinstance(video, torch.Tensor)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,7 +6,11 @@ import pytest
 import torch
 
 from aioway.fn import fake_fn, track_fn
-from aioway.io import read_audio_from_path, read_image_from_path, read_video_from_path
+from aioway.io import (
+    read_audio_from_path,
+    read_image_from_path_torch,
+    read_video_from_path,
+)
 
 
 @pytest.fixture(scope="session")
@@ -73,7 +77,7 @@ def test_example_file_exists(example_file: pathlib.Path):
 
 
 def test_read_img(example_image: pathlib.Path):
-    img = read_image_from_path(example_image)
+    img = read_image_from_path_torch(example_image)
     assert isinstance(img, torch.Tensor)
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,7 +8,7 @@ import torch
 from aioway.fn import fake_fn, track_fn
 from aioway.io import (
     read_audio_from_path,
-    read_image_from_path_torch,
+    read_image_from_path,
     read_video_from_path,
 )
 
@@ -77,7 +77,7 @@ def test_example_file_exists(example_file: pathlib.Path):
 
 
 def test_read_img(example_image: pathlib.Path):
-    img = read_image_from_path_torch(example_image)
+    img = read_image_from_path(example_image)
     assert isinstance(img, torch.Tensor)
 
 


### PR DESCRIPTION
Support more backends s.t. it works better in fake mode.

Added an `ImageLoader` interface, and have a couple of different implementations, including the original torchvision ones.

Now I noticed that `torchvision` `Transform` seems to be using `torch.ops.aten.*` operators, so they work nicely with fake mode.

Fix #204