### PR TITLE
Migrate `DType` to `torch.dtype`.

### DIFF
--- a/src/aioway/fn/tracking.py
+++ b/src/aioway/fn/tracking.py
@@ -4,8 +4,9 @@
 
 import collections
 import dataclasses as dcls
+import itertools
 import logging
-import typing, itertools
+import typing
 
 import rich
 import torch

--- a/src/aioway/schemas/attrs.py
+++ b/src/aioway/schemas/attrs.py
@@ -75,7 +75,7 @@ class Attr:
         return f"[shape={self.shape},dtype={self.dtype},device={self.device},infos={self.infos!r}]"
 
     def memory(self):
-        return self.dtype.bits * self.shape.numel()
+        return self.dtype.itemsize * self.shape.numel()
 
     def to_tensor(self):
         """

--- a/src/aioway/schemas/dtypes.py
+++ b/src/aioway/schemas/dtypes.py
@@ -8,7 +8,7 @@ import typing
 import numpy as np
 import torch
 
-__all__ = ["DType", "DTypeLike"]
+__all__ = ["DType", "DTypeLike", "DTypeFamily"]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -87,10 +87,10 @@ class DType:
             return "float"
 
         elif self.is_signed:
-            return "uint"
+            return "int"
 
         else:
-            return "int"
+            return "uint"
 
     def numpy(self) -> np.dtype:
         "Convert this to a numpy dtype."

--- a/src/aioway/schemas/dtypes.py
+++ b/src/aioway/schemas/dtypes.py
@@ -2,9 +2,7 @@
 
 "The implementation for dtypes, supports different backends."
 
-import functools
 import logging
-import re
 import typing
 
 import numpy as np
@@ -14,11 +12,7 @@ __all__ = ["DType", "DTypeLike"]
 
 LOGGER = logging.getLogger(__name__)
 
-type DTypeFamily = typing.Literal["int", "float", "bool"]
-"""
-The DType strings family type.
-"""
-
+type DTypeFamily = typing.Literal["int", "float", "bool", "uint", "complex"]
 
 type _PrimitiveType = type[int] | type[float] | type[bool]
 type DTypeLike = str | DType | _PrimitiveType | torch.dtype | np.dtype
@@ -35,7 +29,10 @@ class DType:
     def __init__(self, dtype: torch.dtype):
         self._dtype = dtype
 
-    def __str__(self):
+    def __repr__(self) -> str:
+        return f"aioway.{self!s}"
+
+    def __str__(self) -> str:
         """
         Get the representation of the type, must be the most specialized.
         """
@@ -49,9 +46,6 @@ class DType:
     def __hash__(self) -> int:
         return hash(str(self))
 
-    def __repr__(self) -> str:
-        return str(self)
-
     def __eq__(self, other: typing.Any) -> bool:
         try:
             parsed = self.parse(other)
@@ -59,22 +53,44 @@ class DType:
             return NotImplemented
 
         # Parsing sucessful.
-        return self.family == parsed.family and self.bits == parsed.bits
+        return self._dtype == parsed._dtype
 
     @property
-    def family(self) -> DTypeFamily:
-        """
-        The family of the dtype. For example, "float64"'s family is "float".
-        """
-
-        return self._family
-
-    @property
-    def bits(self) -> int:
+    def itemsize(self) -> int:
         """
         The width of the dtype in bytes. Greater or equal to 1.
         """
-        return self._bits
+
+        return self._dtype.itemsize
+
+    @property
+    def is_complex(self) -> bool:
+        return self._dtype.is_complex
+
+    @property
+    def is_floating_point(self) -> bool:
+        return self._dtype.is_floating_point
+
+    @property
+    def is_signed(self) -> bool:
+        return self._dtype.is_signed
+
+    @property
+    def family(self) -> DTypeFamily:
+        if self._dtype == torch.bool:
+            return "bool"
+
+        elif self.is_complex:
+            return "complex"
+
+        elif self.is_floating_point:
+            return "float"
+
+        elif self.is_signed:
+            return "uint"
+
+        else:
+            return "int"
 
     def numpy(self) -> np.dtype:
         "Convert this to a numpy dtype."
@@ -82,7 +98,7 @@ class DType:
 
     def torch(self) -> torch.dtype:
         "Convert this to a torch dtype."
-        return getattr(torch, str(self))
+        return self._dtype
 
     def broadcast(self, other: DTypeLike) -> typing.Self:
         try:
@@ -98,7 +114,7 @@ class DType:
 
     @classmethod
     def boolean(cls) -> typing.Self:
-        return cls(family="bool", bits=8)
+        return cls(torch.bool)
 
     @classmethod
     def parse(cls, dtype: DTypeLike) -> typing.Self:
@@ -118,7 +134,7 @@ class DType:
 
         # Convert with regex.
         if isinstance(dtype, str):
-            return cls._parse_regex(dtype)
+            return cls._parse_str(dtype)
 
         if isinstance(dtype, torch.dtype):
             return cls._parse_torch(dtype)
@@ -130,19 +146,11 @@ class DType:
 
     @classmethod
     def _parse_primitive_type(cls, dtype: type) -> typing.Self:
-        if dtype == int:
-            return cls("int", 64)
-
-        if dtype == float:
-            return cls("float", 32)
-
-        if dtype == bool:
-            return cls("bool", 8)
-
-        raise ValueError(dtype)
+        # Directly delegate to the string parser.
+        return cls._parse_str(dtype.__name__)
 
     @classmethod
-    def _parse_regex(cls, dtype: str, /) -> typing.Self:
+    def _parse_str(cls, dtype: str, /) -> typing.Self:
         """
         Create the `DType` instance from the `info` object.
 
@@ -150,81 +158,20 @@ class DType:
             ValueError: If the dtyep cannot be parsed.
         """
 
-        if m := _int_dtype().match(dtype):
-            _, bits = m.groups()
-            return cls(family="int", bits=int(bits) if bits else 64)
-
-        if m := _float_dtype().match(dtype):
-            _, bits = m.groups()
-            return cls(family="float", bits=int(bits) if bits else 32)
-
-        if m := _bool_dtype().match(dtype):
-            return cls(family="bool", bits=8)
-
-        raise ValueError(dtype)
+        try:
+            torch_dtype = getattr(torch, dtype)
+            return cls(torch_dtype)
+        except AttributeError as err:
+            raise ValueError from err
 
     @classmethod
     @typing.no_type_check
     def _parse_torch(cls, dtype: torch.dtype, /) -> typing.Self:
         "Create a `Dtype` from a `torch.dtype`."
-        if dtype == torch.bool:
-            return cls.boolean()
 
-        if dtype.is_complex:
-            raise ValueError("We do not handle complex types yet!")
-
-        # Itemsize correspond to bytes.
-        bits = dtype.itemsize * 8
-
-        # Both complex and bool are handled above.
-        family: DTypeFamily = "float" if dtype.is_floating_point else "int"
-
-        return cls(family=family, bits=bits)
+        return cls(dtype)
 
     @classmethod
     def _parse_numpy(cls, dtype: np.dtype, /) -> typing.Self:
-        family = _parse_numpy_family(dtype)
-        bits = _parse_numpy_bits(dtype, family)
-
-        return cls(family=family, bits=bits)
-
-
-def _parse_numpy_family(dtype: np.dtype, /) -> DTypeFamily:
-    "Create a `Dtype` from a `numpy.dtype`."
-    if np.isdtype(dtype, "integral"):
-        return "int"
-
-    if np.isdtype(dtype, "real floating"):
-        return "float"
-
-    if np.isdtype(dtype, "bool"):
-        return "bool"
-
-    raise ValueError(f"Cannot handle numpy {dtype=}.")
-
-
-def _parse_numpy_bits(dtype: np.dtype, family: DTypeFamily, /):
-    match family:
-        case "bool":
-            return 8
-        case "int":
-            return np.iinfo(dtype).bits
-        case "float":
-            return np.finfo(dtype).bits
-
-    raise ValueError(f"Unhandled {family=}")
-
-
-@functools.cache
-def _float_dtype():
-    return re.compile(r"^(float)(16|32|64|128)?$", re.IGNORECASE)
-
-
-@functools.cache
-def _int_dtype():
-    return re.compile(r"^(int)(8|16|32|64|128)?$", re.IGNORECASE)
-
-
-@functools.cache
-def _bool_dtype():
-    return re.compile(r"^(bool)$", re.IGNORECASE)
+        # Since `np.dtype` generates nice `str` representation, use it.
+        return cls._parse_str(str(dtype))

--- a/src/aioway/schemas/dtypes.py
+++ b/src/aioway/schemas/dtypes.py
@@ -128,10 +128,6 @@ class DType:
         if isinstance(dtype, cls):
             return dtype
 
-        # Handling the basic types.
-        if isinstance(dtype, type):
-            return cls._parse_primitive_type(dtype)
-
         # Convert with regex.
         if isinstance(dtype, str):
             return cls._parse_str(dtype)
@@ -143,11 +139,6 @@ class DType:
             return cls._parse_numpy(dtype)
 
         raise ValueError(f"Not sure how to handle {dtype=}.")
-
-    @classmethod
-    def _parse_primitive_type(cls, dtype: type) -> typing.Self:
-        # Directly delegate to the string parser.
-        return cls._parse_str(dtype.__name__)
 
     @classmethod
     def _parse_str(cls, dtype: str, /) -> typing.Self:

--- a/src/aioway/schemas/dtypes.py
+++ b/src/aioway/schemas/dtypes.py
@@ -32,32 +32,19 @@ class DType:
     comparison and conversion between different frameworks.
     """
 
-    def __init__(self, family: DTypeFamily, bits: int):
-        if bits % 8 != 0:
-            raise ValueError(f"Bits should be multiple of 8. Got bits={self._bits}.")
-
-        self._family: DTypeFamily = family
-        self._bits: int = bits
+    def __init__(self, dtype: torch.dtype):
+        self._dtype = dtype
 
     def __str__(self):
         """
         Get the representation of the type, must be the most specialized.
-
-        For example, the output should not be "float" due to ambiguity,
-        but rather "float32" or "float64" etc.
         """
 
-        match f := self._family:
-            case "bool":
-                return "bool"
-            case "int" | "float":
-                return f"{f}{self._bits}"
-            case _:
-                raise NotImplementedError(self._family)
+        return str(self._dtype).removeprefix("torch.")
 
     @typing.override
     def __getstate__(self) -> object:
-        return self.family, self.bits
+        return str(self)
 
     def __hash__(self) -> int:
         return hash(str(self))

--- a/src/aioway/schemas/dtypes.py
+++ b/src/aioway/schemas/dtypes.py
@@ -14,8 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 type DTypeFamily = typing.Literal["int", "float", "bool", "uint", "complex"]
 
-type _PrimitiveType = type[int] | type[float] | type[bool]
-type DTypeLike = str | DType | _PrimitiveType | torch.dtype | np.dtype
+type DTypeLike = str | DType | torch.dtype | np.dtype
 "Types that can be converted to `Dtype` with the public `dtype` function (or `DType.parse`)."
 
 

--- a/tests/schemas/test_dtypes.py
+++ b/tests/schemas/test_dtypes.py
@@ -92,6 +92,17 @@ def _dtypes():
     yield np.dtype("uint64"), torch.uint64
     yield torch.uint64, torch.uint64
 
+    yield "complex32", torch.complex32
+    yield torch.complex32, torch.complex32
+
+    yield "complex64", torch.complex64
+    yield np.dtype("complex64"), torch.complex64
+    yield torch.complex64, torch.complex64
+
+    yield "complex128", torch.complex128
+    yield np.dtype("complex128"), torch.complex128
+    yield torch.complex128, torch.complex128
+
 
 @pytest.fixture(params=_golden())
 def golden(request: pytest.FixtureRequest) -> _CaseChecker:

--- a/tests/schemas/test_dtypes.py
+++ b/tests/schemas/test_dtypes.py
@@ -24,12 +24,12 @@ class _CaseChecker:
         return DType(self.torch_dtype)
 
     def check_parse(self):
-        assert isinstance(self.dtype, DType)
-        assert self.dtype == self.rhs
+        assert isinstance(self.dtype, DType), f"{self.original=}, {self.rhs=}"
+        assert self.dtype == self.rhs, f"{self.original=}, {self.rhs=}"
 
     def check_eq(self):
-        assert self.dtype == self.torch_dtype
-        assert self.original == self.rhs
+        assert self.dtype == self.torch_dtype, f"{self.original=}, {self.rhs=}"
+        assert self.original == self.rhs, f"{self.original=}, {self.rhs=}"
 
 
 def _golden():
@@ -38,10 +38,13 @@ def _golden():
 
 
 def _dtypes():
+    "LHS: the data to try parse. RHS: The backing field for `DType`."
+
     yield "float16", torch.float16
     yield np.dtype("float16"), torch.float16
     yield torch.float16, torch.float16
 
+    yield "float", torch.float32
     yield "float32", torch.float32
     yield np.dtype("float32"), torch.float32
     yield torch.float32, torch.float32
@@ -58,10 +61,12 @@ def _dtypes():
     yield np.dtype("int16"), torch.int16
     yield torch.int16, torch.int16
 
+    yield "int", torch.int32
     yield "int32", torch.int32
     yield np.dtype("int32"), torch.int32
     yield torch.int32, torch.int32
 
+    yield "long", torch.int64
     yield "int64", torch.int64
     yield np.dtype("int64"), torch.int64
     yield torch.int64, torch.int64
@@ -69,6 +74,23 @@ def _dtypes():
     yield "bool", torch.bool
     yield np.dtype("bool"), torch.bool
     yield torch.bool, torch.bool
+
+    yield "uint8", torch.uint8
+    yield np.dtype("uint8"), torch.uint8
+    yield torch.uint8, torch.uint8
+
+    yield "uint16", torch.uint16
+    yield np.dtype("uint16"), torch.uint16
+    yield torch.uint16, torch.uint16
+
+    yield "uint32", torch.uint32
+    yield np.dtype("uint32"), torch.uint32
+    yield torch.uint32, torch.uint32
+
+    yield "uint64", torch.uint64
+    yield np.dtype("uint"), torch.uint64
+    yield np.dtype("uint64"), torch.uint64
+    yield torch.uint64, torch.uint64
 
 
 @pytest.fixture(params=_golden())

--- a/tests/schemas/test_dtypes.py
+++ b/tests/schemas/test_dtypes.py
@@ -13,57 +13,62 @@ from aioway.schemas import DType
 @dcls.dataclass(frozen=True)
 class _CaseChecker:
     original: typing.Any
-    family: str
-    bits: int
+    torch_dtype: torch.dtype
 
     @property
     def dtype(self):
         return DType.parse(self.original)
 
-    def check(self):
+    @property
+    def rhs(self):
+        return DType(self.torch_dtype)
+
+    def check_parse(self):
         assert isinstance(self.dtype, DType)
-        assert self.dtype.family == self.family
-        assert self.dtype.bits == self.bits
-        assert self.dtype == self.original
+        assert self.dtype == self.rhs
+
+    def check_eq(self):
+        assert self.dtype == self.torch_dtype
+        assert self.original == self.rhs
 
 
 def _golden():
-    for dtype, family, bits in _dtypes():
-        yield _CaseChecker(original=dtype, family=family, bits=bits)
+    for dtype, torch_dtype in _dtypes():
+        yield _CaseChecker(original=dtype, torch_dtype=torch_dtype)
 
 
 def _dtypes():
-    yield "float16", "float", 16
-    yield np.dtype("float16"), "float", 16
-    yield torch.float16, "float", 16
+    yield "float16", torch.float16
+    yield np.dtype("float16"), torch.float16
+    yield torch.float16, torch.float16
 
-    yield "float32", "float", 32
-    yield np.dtype("float32"), "float", 32
-    yield torch.float32, "float", 32
+    yield "float32", torch.float32
+    yield np.dtype("float32"), torch.float32
+    yield torch.float32, torch.float32
 
-    yield "float64", "float", 64
-    yield np.dtype("float64"), "float", 64
-    yield torch.float64, "float", 64
+    yield "float64", torch.float64
+    yield np.dtype("float64"), torch.float64
+    yield torch.float64, torch.float64
 
-    yield "int8", "int", 8
-    yield np.dtype("int8"), "int", 8
-    yield torch.int8, "int", 8
+    yield "int8", torch.int8
+    yield np.dtype("int8"), torch.int8
+    yield torch.int8, torch.int8
 
-    yield "int16", "int", 16
-    yield np.dtype("int16"), "int", 16
-    yield torch.int16, "int", 16
+    yield "int16", torch.int16
+    yield np.dtype("int16"), torch.int16
+    yield torch.int16, torch.int16
 
-    yield "int32", "int", 32
-    yield np.dtype("int32"), "int", 32
-    yield torch.int32, "int", 32
+    yield "int32", torch.int32
+    yield np.dtype("int32"), torch.int32
+    yield torch.int32, torch.int32
 
-    yield "int64", "int", 64
-    yield np.dtype("int64"), "int", 64
-    yield torch.int64, "int", 64
+    yield "int64", torch.int64
+    yield np.dtype("int64"), torch.int64
+    yield torch.int64, torch.int64
 
-    yield "bool", "bool", 8
-    yield np.dtype("bool"), "bool", 8
-    yield torch.bool, "bool", 8
+    yield "bool", torch.bool
+    yield np.dtype("bool"), torch.bool
+    yield torch.bool, torch.bool
 
 
 @pytest.fixture(params=_golden())
@@ -71,5 +76,9 @@ def golden(request: pytest.FixtureRequest) -> _CaseChecker:
     return request.param
 
 
-def test_dtype_cases(golden: _CaseChecker):
-    golden.check()
+def test_dtype_parse(golden: _CaseChecker):
+    golden.check_parse()
+
+
+def test_dtype_eq(golden: _CaseChecker):
+    golden.check_eq()

--- a/tests/schemas/test_dtypes.py
+++ b/tests/schemas/test_dtypes.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from aioway.schemas import DType
+from aioway.schemas import DTypeFamily
 
 
 @dcls.dataclass(frozen=True)
@@ -24,12 +25,38 @@ class _CaseChecker:
         return DType(self.torch_dtype)
 
     def check_parse(self):
-        assert isinstance(self.dtype, DType), f"{self.original=}, {self.rhs=}"
-        assert self.dtype == self.rhs, f"{self.original=}, {self.rhs=}"
+        assert isinstance(self.dtype, DType), self.__test_case
+        assert self.dtype == self.rhs, self.__test_case
 
     def check_eq(self):
-        assert self.dtype == self.torch_dtype, f"{self.original=}, {self.rhs=}"
-        assert self.original == self.rhs, f"{self.original=}, {self.rhs=}"
+        assert self.dtype == self.torch_dtype, self.__test_case
+        assert self.original == self.rhs, self.__test_case
+
+    def check_family(self):
+        assert self.rhs.family == self.family, self.__test_case
+
+    @property
+    def family(self) -> DTypeFamily:
+        if self.torch_dtype == torch.bool:
+            return "bool"
+
+        if self.torch_dtype in [torch.complex32, torch.complex64, torch.complex128]:
+            return "complex"
+
+        if self.torch_dtype in [torch.uint8, torch.uint16, torch.uint32, torch.uint64]:
+            return "uint"
+
+        if self.torch_dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
+            return "int"
+
+        if self.torch_dtype in [torch.float16, torch.float32, torch.float64]:
+            return "float"
+
+        raise ValueError(f"Unknown type: {self.torch_dtype}")
+
+    @property
+    def __test_case(self):
+        return f"{self.original=}, {self.rhs=}, {self.family=}"
 
 
 def _golden():
@@ -110,8 +137,15 @@ def golden(request: pytest.FixtureRequest) -> _CaseChecker:
 
 
 def test_dtype_parse(golden: _CaseChecker):
+    "Check the `DType.parse` different objects."
     golden.check_parse()
 
 
 def test_dtype_eq(golden: _CaseChecker):
+    "Check the `==` operator of `DType`."
     golden.check_eq()
+
+
+def test_dtype_family(golden: _CaseChecker):
+    "Check the family of the case."
+    golden.check_family()


### PR DESCRIPTION
We are now directly a `torch` framework, so we'll just directly use `torch.dtype`.

This expands support for `uint` and `complex` types.


Fix #222