### PR TITLE
Torch mode improvement for cloning

### DIFF
--- a/src/aioway/_common/decomps.py
+++ b/src/aioway/_common/decomps.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 import tensordict as td
 import torch
-from torch.utils import _mode_utils
 
 __all__ = [
     "replace_tensors",

--- a/src/aioway/_common/decomps.py
+++ b/src/aioway/_common/decomps.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import tensordict as td
 import torch
+from torch.utils import _mode_utils
 
 __all__ = [
     "replace_tensors",
@@ -41,9 +42,9 @@ DECOMP_BLOCK_TYPES = (
 def replace_tensors(
     obj: object, replace: cabc.Callable[[torch.Tensor], object]
 ) -> object:
-    from aioway.fn import torch_function_off
+    from aioway.fn import set_torch_mode
 
-    with torch_function_off():
+    with set_torch_mode(False, False):
         return _replace_tensors(obj, replace)
 
 

--- a/src/aioway/fate/fate.py
+++ b/src/aioway/fate/fate.py
@@ -1,10 +1,13 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
+"The module containing `Fate` interface, the implementation for fake aten operations."
+
 import abc
 import dataclasses as dcls
 import inspect
 import re
 import typing
+from collections import abc as cabc
 
 import torch
 from torch import _ops
@@ -28,7 +31,7 @@ class Fate(abc.ABC):
     For example, boolean masking is data dependent, and is thus not supported by fake mode.
     """
 
-    IR: typing.ClassVar[_ops.OpOverload]
+    IR: typing.ClassVar[_ops.OpOverload | tuple[_ops.OpOverload, ...]]
     """
     The torch IR that this `Fate` would be implementing.
     """
@@ -87,16 +90,30 @@ class Fate(abc.ABC):
 
         # Abstract `ClassVar`.
         try:
-            op = cls.IR
+            ir = cls.IR
         except AttributeError:
             return
 
-        # Mimick defaultdict behavior.
-        # Using dict over defaultdict s.t. we don't need special handling in `repr`.
-        if op not in _ATEN_TO_FATE_LIST:
-            _ATEN_TO_FATE_LIST[op] = []
+        for op in _get_overloads(ir):
+            # Mimick defaultdict behavior.
+            # Using dict over defaultdict s.t. we don't need special handling in `repr`.
+            if op not in _ATEN_TO_FATE_LIST:
+                _ATEN_TO_FATE_LIST[op] = []
 
-        _ATEN_TO_FATE_LIST[op].append(cls)
+            _ATEN_TO_FATE_LIST[op].append(cls)
+
+
+def _get_overloads(obj: _ops.OpOverload | cabc.Sequence[_ops.OpOverload], /):
+    "Convert the input cls.IR into iterable of `torch._ops.OpOverload`."
+
+    if isinstance(obj, _ops.OpOverload):
+        yield obj
+        return
+
+    assert isinstance(obj, cabc.Sequence)
+    for op in obj:
+        assert isinstance(op, _ops.OpOverload), type(op)
+        yield op
 
 
 def find_fate(op: _ops.OpOverload, *args: typing.Any, **kwargs: typing.Any) -> Fate:

--- a/src/aioway/fn/__init__.py
+++ b/src/aioway/fn/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-from .ctx import *
+from .fake import *
 from .fn import *
 from .modes import *
 from .routers import *

--- a/src/aioway/fn/fake.py
+++ b/src/aioway/fn/fake.py
@@ -21,8 +21,6 @@ __all__ = [
     "to_fake_tensordict",
     "enabled_fake_mode",
     "torch_real_mode",
-    "torch_function_off",
-    "torch_function_off_func",
 ]
 
 LOGGER = logging.getLogger(__name__)
@@ -125,29 +123,6 @@ def _set_fake_mode_flag(to: bool):
         yield _fake_mode_is_active
     finally:
         _fake_mode_is_active = before
-
-
-@ctxl.contextmanager
-def torch_function_off():
-    """
-    Disable `__torch_function__` mode, for the given scope.
-    """
-
-    with torch.DisableTorchFunction():
-        yield
-
-
-def torch_function_off_func[**P, T](func: cabc.Callable[P, T]) -> cabc.Callable[P, T]:
-    """
-    Disable `__torch_function__` mode, for the wrapped function.
-    """
-
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-        with torch_function_off():
-            return func(*args, **kwargs)
-
-    _set_wrapper_func(wrapper, func)
-    return wrapper
 
 
 def torch_enable_fake_mode_func(to: bool, /):

--- a/src/aioway/fn/fn.py
+++ b/src/aioway/fn/fn.py
@@ -27,7 +27,7 @@ class Fn(abc.ABC):
     """
 
     @abc.abstractmethod
-    def do(self) -> typing.Any:
+    def do(self) -> object:
         """
         Execute the computation.
         """
@@ -93,7 +93,7 @@ class Thunk(Fn):
 
         return NotImplemented
 
-    def do(self) -> typing.Any:
+    def do(self) -> object:
         """
         Call and cache the function.
         """

--- a/src/aioway/fn/modes.py
+++ b/src/aioway/fn/modes.py
@@ -10,7 +10,8 @@ from collections import abc as cabc
 
 import torch
 from torch import _ops, overrides
-from torch.utils import _python_dispatch as pyd, _mode_utils as mu
+from torch.utils import _mode_utils as mu
+from torch.utils import _python_dispatch as pyd
 
 from aioway._common import (
     Decomposer,
@@ -23,7 +24,6 @@ from aioway._common import (
     replace_tensors,
 )
 from aioway.fate import Fate, find_fate
-from aioway.fn import enabled_fake_mode
 from aioway.schemas import attr
 
 from .fn import Fn
@@ -150,25 +150,6 @@ class TFunctionFn(TFunctionFnMixin, _TThunkBase[cabc.Callable[..., typing.Any]])
 class TDispatchFnMixin(Fn, abc.ABC):
     "The mixin to define what types `Fn` graph would capture during dispatch mode."
 
-    @typing.final
-    @typing.override
-    def do(self) -> object:
-        result = self._do()
-
-        # In fake mode, clone the tensor s.t. each `Fn` has a unique `torch.Tensor`.
-        # Otherwise sometimes `torch` reuses `FakeTensor` due to performance.
-        if enabled_fake_mode():
-            return replace_tensors(result, lambda tensor: tensor.clone())
-
-        else:
-            return result
-
-    @abc.abstractmethod
-    def _do(self) -> object:
-        "This is the implementation of `do`, whose result would be cloned in fake mode in `do`."
-
-        raise NotImplementedError
-
     @typing.override
     def inputs(self) -> cabc.Iterator[TDispatchFn | FateFn]:
         finder = Decomposer(target=lambda t: isinstance(t, FateFn | TDispatchFn))
@@ -195,10 +176,6 @@ class TDispatchFn(TDispatchFnMixin, _TThunkBase[_ops.OpOverload]):
 
     def __repr__(self) -> str:
         return _render_function_body("dispatch", self.func, self.args, self.kwargs)
-
-    @typing.override
-    def _do(self) -> object:
-        return _TThunkBase.do(self)
 
     @property
     def is_aten(self) -> bool:
@@ -300,7 +277,7 @@ class FateFn(HasParam, TDispatchFnMixin):
         return repr(self.fate)
 
     @typing.override
-    def _do(self) -> torch.Tensor:
+    def do(self) -> torch.Tensor:
         return self.fate.do()
 
     @typing.override

--- a/src/aioway/fn/modes.py
+++ b/src/aioway/fn/modes.py
@@ -22,6 +22,7 @@ from aioway._common import (
     replace_tensors,
 )
 from aioway.fate import Fate, find_fate
+from aioway.fn.ctx import enabled_fake_mode
 from aioway.schemas import attr
 
 from .fn import Fn
@@ -33,7 +34,7 @@ type _TorchCallable = cabc.Callable[..., typing.Any] | _ops.OpOverload
 
 
 @dcls.dataclass(match_args=False)
-class _TThunkBase[T: _TorchCallable](HasParam, abc.ABC):
+class _TThunkBase[T: _TorchCallable](HasParam, Fn, abc.ABC):
     """
     `TorchThunkFn` is the thunk capturing the function calls initiated by `torch`.
     It's the base class for both `TorchFunctionFn` and `TorchDispatchFn`
@@ -63,8 +64,7 @@ class _TThunkBase[T: _TorchCallable](HasParam, abc.ABC):
             raise TypeError(f"{self.kwargs=} is not a dict.")
 
     @typing.override
-    @typing.no_type_check
-    def do(self) -> torch.Tensor:
+    def do(self) -> object:
         return self.func(*self.args, **self.kwargs)
 
     @typing.override
@@ -83,7 +83,7 @@ class TFunctionFnMixin(Fn, abc.ABC):
 
 
 @dcls.dataclass(match_args=False)
-class TFunctionFn(_TThunkBase[cabc.Callable[..., typing.Any]], TFunctionFnMixin):
+class TFunctionFn(TFunctionFnMixin, _TThunkBase[cabc.Callable[..., typing.Any]]):
     """
     `TorchFunctionT` is the thunk capturing the function calls initiated by `torch`.
 
@@ -103,6 +103,25 @@ class TFunctionFn(_TThunkBase[cabc.Callable[..., typing.Any]], TFunctionFnMixin)
 class TDispatchFnMixin(Fn, abc.ABC):
     "The mixin to define what types `Fn` graph would capture during dispatch mode."
 
+    @typing.final
+    @typing.override
+    def do(self) -> object:
+        result = self._do()
+
+        # In fake mode, clone the tensor s.t. each `Fn` has a unique `torch.Tensor`.
+        # Otherwise sometimes `torch` reuses `FakeTensor` due to performance.
+        if enabled_fake_mode():
+            return replace_tensors(result, lambda tensor: tensor.clone())
+
+        else:
+            return result
+
+    @abc.abstractmethod
+    def _do(self) -> object:
+        "This is the implementation of `do`, whose result would be cloned in fake mode in `do`."
+
+        raise NotImplementedError
+
     @typing.override
     def inputs(self) -> cabc.Iterator[TDispatchFn | FateFn]:
         finder = Decomposer(target=lambda t: isinstance(t, FateFn | TDispatchFn))
@@ -110,7 +129,7 @@ class TDispatchFnMixin(Fn, abc.ABC):
 
 
 @dcls.dataclass(match_args=False)
-class TDispatchFn(_TThunkBase[_ops.OpOverload], TDispatchFnMixin):
+class TDispatchFn(TDispatchFnMixin, _TThunkBase[_ops.OpOverload]):
     """
     `TorchDispatchT` is the thunk capturing the function calls initiated by `torch`.
     This is by default what a null-op `__torch_dispatch__` would call.
@@ -129,6 +148,10 @@ class TDispatchFn(_TThunkBase[_ops.OpOverload], TDispatchFnMixin):
 
     def __repr__(self) -> str:
         return _render_function_body("dispatch", self.func, self.args, self.kwargs)
+
+    @typing.override
+    def _do(self) -> object:
+        return _TThunkBase.do(self)
 
     @property
     def is_aten(self) -> bool:
@@ -169,12 +192,12 @@ class TFunctionMode(overrides.TorchFunctionMode, abc.ABC):
     """
 
     @abc.abstractmethod
-    def __call__(self, thunk: TFunctionFn, /) -> torch.Tensor:
+    def __call__(self, thunk: TFunctionFn, /) -> object:
         raise NotImplementedError
 
     @typing.final
     @typing.override
-    def __torch_function__(self, func, types, args=(), kwargs=None):
+    def __torch_function__(self, func, types, args=(), kwargs=None) -> object:
         kwargs = kwargs or {}
         thunk = TFunctionFn(func=func, types=types, args=args, kwargs=kwargs)
         return self(thunk)
@@ -186,12 +209,12 @@ class TDispatchMode(pyd.TorchDispatchMode, abc.ABC):
     """
 
     @abc.abstractmethod
-    def __call__(self, thunk: TDispatchFn, /) -> torch.Tensor:
+    def __call__(self, thunk: TDispatchFn, /) -> object:
         raise NotImplementedError
 
     @typing.final
     @typing.override
-    def __torch_dispatch__(self, func, types, args=(), kwargs=None) -> typing.Any:
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None) -> object:
         kwargs = kwargs or {}
 
         if not all(issubclass(t, torch.Tensor) for t in types):
@@ -222,7 +245,8 @@ class FateFn(HasParam, TDispatchFnMixin):
     def __repr__(self) -> str:
         return repr(self.fate)
 
-    def do(self) -> torch.Tensor:
+    @typing.override
+    def _do(self) -> torch.Tensor:
         return self.fate.do()
 
     @typing.override

--- a/src/aioway/fn/modes.py
+++ b/src/aioway/fn/modes.py
@@ -3,13 +3,14 @@
 "Torch function/dispatch modes, corresponding to `__torch_function__`/`__torch_dispatch__`."
 
 import abc
+import contextlib as ctxl
 import dataclasses as dcls
 import typing
 from collections import abc as cabc
 
 import torch
 from torch import _ops, overrides
-from torch.utils import _python_dispatch as pyd
+from torch.utils import _python_dispatch as pyd, _mode_utils as mu
 
 from aioway._common import (
     Decomposer,
@@ -22,15 +23,61 @@ from aioway._common import (
     replace_tensors,
 )
 from aioway.fate import Fate, find_fate
-from aioway.fn.ctx import enabled_fake_mode
+from aioway.fn import enabled_fake_mode
 from aioway.schemas import attr
 
 from .fn import Fn
 
-__all__ = ["TFunctionMode", "TDispatchMode", "TFunctionFn", "TDispatchFn", "FateFn"]
+__all__ = [
+    "TFunctionMode",
+    "TDispatchMode",
+    "TFunctionFn",
+    "TDispatchFn",
+    "FateFn",
+    "set_torch_mode",
+    "torch_mode_off",
+]
 
 
 type _TorchCallable = cabc.Callable[..., typing.Any] | _ops.OpOverload
+
+_do_aioway_function: bool = True
+"If `False`, `TFunctionMode` won't do anything."
+
+_do_aioway_dispatch: bool = True
+"If `False`, `TDispatchMode` won't do anything."
+
+
+@ctxl.contextmanager
+def set_torch_mode(function: bool, dispatch: bool):
+    """
+    Turn on or off `__torch_function__` / `__torch_dispatch__` mode for the given scope,
+    for those defined in `aioway`, depending on the flags.
+
+    Args:
+        function: Disable the `__torch_function__` mode if `True`.
+        dispatch: Disable the `__torch_dispatch__` mode if `True`.
+
+    Note:
+        We are implementing this flag instead of using `no_dispatch` utility from `torch`,
+        is because thier version causes segmentation fault in some cases.
+    """
+
+    global _do_aioway_function, _do_aioway_dispatch
+    before = _do_aioway_function, _do_aioway_dispatch
+
+    try:
+        _do_aioway_function = function
+        _do_aioway_dispatch = dispatch
+        yield
+    finally:
+        _do_aioway_function, _do_aioway_dispatch = before
+
+
+@ctxl.contextmanager
+def torch_mode_off():
+    with torch.DisableTorchFunction(), mu.no_dispatch():
+        yield
 
 
 @dcls.dataclass(match_args=False)
@@ -199,6 +246,10 @@ class TFunctionMode(overrides.TorchFunctionMode, abc.ABC):
     @typing.override
     def __torch_function__(self, func, types, args=(), kwargs=None) -> object:
         kwargs = kwargs or {}
+
+        if not _do_aioway_function:
+            return func(*args, **kwargs)
+
         thunk = TFunctionFn(func=func, types=types, args=args, kwargs=kwargs)
         return self(thunk)
 
@@ -219,6 +270,9 @@ class TDispatchMode(pyd.TorchDispatchMode, abc.ABC):
 
         if not all(issubclass(t, torch.Tensor) for t in types):
             raise AssertionError(f"Not all {types=} are subclasses of `torch.Tensor`.")
+
+        if not _do_aioway_dispatch:
+            return func(*args, **kwargs)
 
         thunk = TDispatchFn(func=func, args=args, kwargs=kwargs)
         return self(thunk)

--- a/src/aioway/fn/routers.py
+++ b/src/aioway/fn/routers.py
@@ -6,9 +6,11 @@ import logging
 import typing
 from collections import abc as cabc
 
+from torch import ops
+
 from aioway._common import is_aten_op, is_prim_op, is_torchcodec_op, is_torchvision_op
 
-from .ctx import enabled_fake_mode, torch_fake_mode
+from .fake import enabled_fake_mode, torch_fake_mode
 from .modes import FateFn, TDispatchFn, TDispatchMode, TFunctionFn, TFunctionMode
 from .tracking import FnHistory
 
@@ -54,6 +56,28 @@ def only_route_in_fake(thunk: TDispatchFn):
 
 def no_route(thunk: TDispatchFn):
     return NotImplemented
+
+
+class NoInplaceOp(TDispatchMode):
+    """
+    `NoInplaceOp` replaces the inplace `torch.ops.*` ops with their functional counterpart.
+
+    Since all pytorch inplace ops has a suffix "_", I'm using that as identifier.
+
+    This must be applied before any other thunk routing.
+    """
+
+    @typing.override
+    def __call__(self, thunk: TDispatchFn, /) -> object:
+        if not isinstance(thunk, TDispatchFn):
+            raise TypeError(f"Thunk is already rerouted as {thunk}.")
+
+        # Replace with non in place version, in fake mode.
+        if (func_name := str(thunk.func)).endswith("_") and enabled_fake_mode():
+            func = getattr(ops, func_name.removesuffix("_"))
+            thunk = TDispatchFn(func=func, args=thunk.args, kwargs=thunk.kwargs)
+
+        return thunk.do()
 
 
 @dcls.dataclass

--- a/src/aioway/fn/routers.py
+++ b/src/aioway/fn/routers.py
@@ -6,9 +6,8 @@ import logging
 import typing
 from collections import abc as cabc
 
-from torch import ops
-
 from aioway._common import is_aten_op, is_prim_op, is_torchcodec_op, is_torchvision_op
+from aioway._common.decomps import replace_tensors
 
 from .fake import enabled_fake_mode, torch_fake_mode
 from .modes import FateFn, TDispatchFn, TDispatchMode, TFunctionFn, TFunctionMode
@@ -58,26 +57,16 @@ def no_route(thunk: TDispatchFn):
     return NotImplemented
 
 
-class NoInplaceOp(TDispatchMode):
-    """
-    `NoInplaceOp` replaces the inplace `torch.ops.*` ops with their functional counterpart.
-
-    Since all pytorch inplace ops has a suffix "_", I'm using that as identifier.
-
-    This must be applied before any other thunk routing.
-    """
-
+class CloneDispatchOp(TDispatchMode):
     @typing.override
     def __call__(self, thunk: TDispatchFn, /) -> object:
-        if not isinstance(thunk, TDispatchFn):
-            raise TypeError(f"Thunk is already rerouted as {thunk}.")
+        result = thunk.do()
 
-        # Replace with non in place version, in fake mode.
-        if (func_name := str(thunk.func)).endswith("_") and enabled_fake_mode():
-            func = getattr(ops, func_name.removesuffix("_"))
-            thunk = TDispatchFn(func=func, args=thunk.args, kwargs=thunk.kwargs)
+        # In fake mode, clone the tensor to prevent `FakeTensor` reuse. Should be cheap.
+        if enabled_fake_mode():
+            result = replace_tensors(result, lambda tensor: tensor.clone())
 
-        return thunk.do()
+        return result
 
 
 @dcls.dataclass
@@ -162,5 +151,5 @@ def fake_fn():
     dispatcher = RouteDispatchOp(only_route_in_fake)
     tracker = RouteFunctionOp(dispatcher)
 
-    with torch_fake_mode(), tracker:
+    with torch_fake_mode(), tracker, CloneDispatchOp():
         yield tracker.history, dispatcher.history

--- a/src/aioway/fn/routers.py
+++ b/src/aioway/fn/routers.py
@@ -6,8 +6,6 @@ import logging
 import typing
 from collections import abc as cabc
 
-import torch
-
 from aioway._common import is_aten_op, is_prim_op, is_torchcodec_op, is_torchvision_op
 
 from .ctx import enabled_fake_mode, torch_fake_mode
@@ -59,17 +57,11 @@ def no_route(thunk: TDispatchFn):
 
 
 @dcls.dataclass
-class EnsureOnce(TDispatchMode):
-    def __call__(self, thunk: TDispatchFn) -> torch.Tensor:
-        return thunk.do()
-
-
-@dcls.dataclass
 class RouteDispatchOp(TDispatchMode):
     router: FateRouter
     history: FnHistory[TDispatchFn | FateFn] = dcls.field(default_factory=FnHistory)
 
-    def __call__(self, thunk: TDispatchFn) -> torch.Tensor:
+    def __call__(self, thunk: TDispatchFn) -> object:
         # Create a `_ThunkType` and route implemented methods.
 
         fn: TDispatchFn | FateFn
@@ -107,7 +99,7 @@ class RouteFunctionOp(TFunctionMode):
     """
 
     @typing.override
-    def __call__(self, thunk: TFunctionFn, /) -> torch.Tensor:
+    def __call__(self, thunk: TFunctionFn, /) -> object:
         with self.dispatch_router:
             result = thunk.do()
 

--- a/src/aioway/fn/tracking.py
+++ b/src/aioway/fn/tracking.py
@@ -40,7 +40,7 @@ class PrintTorchFunction(TFunctionMode):
     rich: bool = False
 
     @typing.override
-    def __call__(self, thunk: TFunctionFn, /) -> torch.Tensor:
+    def __call__(self, thunk: TFunctionFn, /) -> object:
         return _ThunkPrinter(rich=self.rich)(thunk)
 
 
@@ -48,7 +48,7 @@ class PrintTorchDispatch(TDispatchMode):
     rich: bool = False
 
     @typing.override
-    def __call__(self, thunk: TDispatchFn, /) -> torch.Tensor:
+    def __call__(self, thunk: TDispatchFn, /) -> object:
         return _ThunkPrinter(rich=self.rich)(thunk)
 
 
@@ -57,7 +57,7 @@ class _ThunkPrinter:
     rich: bool
     "Use rich for printing."
 
-    def __call__(self, thunk: TFunctionFn | TDispatchFn) -> torch.Tensor:
+    def __call__(self, thunk: TFunctionFn | TDispatchFn) -> object:
         self.print("invoke", thunk)
         result = thunk.do()
         self.print("return", thunk, "->", replace_tensors_with_attr(result))
@@ -81,7 +81,7 @@ class LogTorchFunction(TFunctionMode):
     "The logger to log to. Default to the one in the current module."
 
     @typing.override
-    def __call__(self, thunk: TFunctionFn) -> torch.Tensor:
+    def __call__(self, thunk: TFunctionFn) -> object:
         result = thunk.do()
         self.logger.log(self.level, "%s", thunk)
         return result
@@ -100,7 +100,7 @@ class LogTorchDispatch(TDispatchMode):
     "The logger to log to. Default to the one in the current module."
 
     @typing.override
-    def __call__(self, thunk: TDispatchFn) -> torch.Tensor:
+    def __call__(self, thunk: TDispatchFn) -> object:
         result = thunk.do()
         self.logger.log(self.level, "%s", thunk)
         return result
@@ -121,7 +121,7 @@ class TorchDispatchStack(TDispatchMode):
     stack: Stack[TDispatchFn] = dcls.field(default_factory=Stack)
 
     @typing.override
-    def __call__(self, thunk: TDispatchFn) -> torch.Tensor:
+    def __call__(self, thunk: TDispatchFn) -> object:
         with self.stack.enter(thunk):
             return thunk.do()
 
@@ -172,14 +172,14 @@ class FnHistory[T: FateFn | TFunctionFn | TDispatchFn]:
     def __iter__(self):
         yield from self.history
 
-    def append(self, item: T, result: typing.Any, /):
+    def append(self, item: T, result: object, /):
         self.history.append(FnResult(item, result))
         self._update_ref(item, result)
 
     def pop(self):
         return self.history.pop()
 
-    def _update_ref(self, item: T, output: typing.Any) -> None:
+    def _update_ref(self, item: T, output: object) -> None:
         # `__torch_function__` doesn't always return `torch.Tensor` actually!
         if isinstance(output, torch.Tensor):
             # Update output.

--- a/tests/fn/test_modes.py
+++ b/tests/fn/test_modes.py
@@ -6,11 +6,11 @@ import torch
 from aioway.fn import (
     TorchDispatchStack,
     TorchFunctionStack,
+    enabled_fake_mode,
     fake_fn,
     torch_fake_mode,
     track_fn,
 )
-from aioway.fn.ctx import enabled_fake_mode
 
 
 @pytest.fixture

--- a/tests/io/test_images.py
+++ b/tests/io/test_images.py
@@ -5,7 +5,7 @@ import pathlib
 import pytest
 import torch
 
-from aioway.fn.ctx import is_fake_tensor
+from aioway.fn import is_fake_tensor
 from aioway.io import (
     ImageLoader,
     PillowImageLoader,

--- a/tests/schemas/test_dtypes.py
+++ b/tests/schemas/test_dtypes.py
@@ -7,8 +7,7 @@ import numpy as np
 import pytest
 import torch
 
-from aioway.schemas import DType
-from aioway.schemas import DTypeFamily
+from aioway.schemas import DType, DTypeFamily
 
 
 @dcls.dataclass(frozen=True)


### PR DESCRIPTION
1. Toggle to control to turn off all `aioway` defined `__torch_function__` and `__torch_dispatch__` modes.
2. Cloning by default in fake mode for easier tracking.
3. Expand `Fate` to support multiple IRs if available.

Fix #227 