### PR TITLE
Make torchcodec optional in dev builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 BASH := python3 ci/launch.py bash
-SHELL := $(if $(BASH),$(BASH),bash)
+SH := $(if $(BASH),$(BASH),bash)
 
 OS := $(shell uname -s)
 PYTEST_FLAGS := 
@@ -14,50 +14,50 @@ SUDO := sudo -E
 setup: cleanup deps
 
 cleanup:
-	@$(SUDO) $(SHELL) ci/cleanup-github.sh
+	@$(SUDO) $(SH) ci/cleanup-github.sh
 
 deps:
 	@echo "Installing dependencies for $(OS)"
 
 ifeq ($(OS),Linux)
-	@$(SUDO) $(SHELL) ci/install-linux.sh
+	@$(SUDO) $(SH) ci/install-linux.sh
 else ifeq ($(OS),Darwin)
-	@$(SHELL) ci/install-mac.sh
+	@$(SH) ci/install-mac.sh
 else
 	@echo "Unsupported OS: $(OS)"
 	@exit 1
 endif
 
 publish:
-	@$(SHELL) ci/pdm.sh publish
+	@$(SH) ci/pdm.sh publish
 
 build:
-	@$(SHELL) ci/pdm.sh build
+	@$(SH) ci/pdm.sh build
 
 install:
-	@$(SHELL) ci/pdm.sh install "-G:all"
+	@$(SH) ci/pdm.sh install "-G:all"
 
 sync:
-	@$(SHELL) ci/pdm.sh sync "-G:all"
+	@$(SH) ci/pdm.sh sync "-G:all"
 
 pytest:
-	@$(SHELL) ci/pdm.sh run pytest $(PYTEST_FLAGS)
+	@$(SH) ci/pdm.sh run pytest $(PYTEST_FLAGS)
 
 autoflake:
-	@$(SHELL) ci/pdm.sh run autoflake . $(CHECK_FLAG)
+	@$(SH) ci/pdm.sh run autoflake . $(CHECK_FLAG)
 
 black:
-	@$(SHELL) ci/pdm.sh run black . $(CHECK_FLAG)
+	@$(SH) ci/pdm.sh run black . $(CHECK_FLAG)
 
 isort:
-	@$(SHELL) ci/pdm.sh run isort . $(CHECK_FLAG)
+	@$(SH) ci/pdm.sh run isort . $(CHECK_FLAG)
 
 mypy:
-	@$(SHELL) ci/pdm.sh run mypy --install-types --non-interactive src
+	@$(SH) ci/pdm.sh run mypy --install-types --non-interactive src
 
 
 sphinx:
-	@$(SHELL) ci/pdm.sh run make -C docs html
+	@$(SH) ci/pdm.sh run make -C docs html
 
 docs: sphinx
-	@$(SHELL) ci/docs.sh
+	@$(SH) ci/docs.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-BASH := python3 ci/launch.py bash
-SH := $(if $(BASH),$(BASH),bash)
+SH := python3 ci/launch.py bash
 
 OS := $(shell uname -s)
 PYTEST_FLAGS := 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 BASH := python3 ci/launch.py bash
-LAUNCH := $(if $(BASH),$(BASH),bash)
+SHELL := $(if $(BASH),$(BASH),bash)
 
 OS := $(shell uname -s)
 PYTEST_FLAGS := 
@@ -14,50 +14,50 @@ SUDO := sudo -E
 setup: cleanup deps
 
 cleanup:
-	@$(SUDO) $(LAUNCH) ci/cleanup-github.sh
+	@$(SUDO) $(SHELL) ci/cleanup-github.sh
 
 deps:
 	@echo "Installing dependencies for $(OS)"
 
 ifeq ($(OS),Linux)
-	@$(SUDO) $(LAUNCH) ci/install-linux.sh
+	@$(SUDO) $(SHELL) ci/install-linux.sh
 else ifeq ($(OS),Darwin)
-	@$(LAUNCH) ci/install-mac.sh
+	@$(SHELL) ci/install-mac.sh
 else
 	@echo "Unsupported OS: $(OS)"
 	@exit 1
 endif
 
 publish:
-	@$(LAUNCH) ci/pdm.sh publish
+	@$(SHELL) ci/pdm.sh publish
 
 build:
-	@$(LAUNCH) ci/pdm.sh build
+	@$(SHELL) ci/pdm.sh build
 
 install:
-	@$(LAUNCH) ci/pdm.sh install "-G:all"
+	@$(SHELL) ci/pdm.sh install "-G:all"
 
 sync:
-	@$(LAUNCH) ci/pdm.sh sync "-G:all"
+	@$(SHELL) ci/pdm.sh sync "-G:all"
 
 pytest:
-	@$(LAUNCH) ci/pdm.sh run pytest $(PYTEST_FLAGS)
+	@$(SHELL) ci/pdm.sh run pytest $(PYTEST_FLAGS)
 
 autoflake:
-	@$(LAUNCH) ci/pdm.sh run autoflake . $(CHECK_FLAG)
+	@$(SHELL) ci/pdm.sh run autoflake . $(CHECK_FLAG)
 
 black:
-	@$(LAUNCH) ci/pdm.sh run black . $(CHECK_FLAG)
+	@$(SHELL) ci/pdm.sh run black . $(CHECK_FLAG)
 
 isort:
-	@$(LAUNCH) ci/pdm.sh run isort . $(CHECK_FLAG)
+	@$(SHELL) ci/pdm.sh run isort . $(CHECK_FLAG)
 
 mypy:
-	@$(LAUNCH) ci/pdm.sh run mypy --install-types --non-interactive src
+	@$(SHELL) ci/pdm.sh run mypy --install-types --non-interactive src
 
 
 sphinx:
-	@$(LAUNCH) ci/pdm.sh run make -C docs html
+	@$(SHELL) ci/pdm.sh run make -C docs html
 
 docs: sphinx
-	@$(LAUNCH) ci/docs.sh
+	@$(SHELL) ci/docs.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-LAUNCHER := python3 ci/launch.py bash
-LAUNCH := $(if $(LAUNCHER),$(LAUNCHER),bash)
+BASH := python3 ci/launch.py bash
+LAUNCH := $(if $(BASH),$(BASH),bash)
 
 OS := $(shell uname -s)
 PYTEST_FLAGS := 

--- a/ci/launch.py
+++ b/ci/launch.py
@@ -1,8 +1,8 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
-import shutil
 import argparse
 import os
+import shutil
 import subprocess
 import textwrap
 

--- a/ci/launch.py
+++ b/ci/launch.py
@@ -33,8 +33,7 @@ def box(text: str) -> str:
 def launch_proc_and_print(command: list[str], indent: str) -> int:
     # Set columns to current terminal size - indent.
     env = os.environ.copy()
-    env["COLUMNS"] = str(os.get_terminal_size().columns - len(indent))
-    env["LINES"] = str(os.get_terminal_size().lines)
+    env.update(_update_term_size(indent))
 
     p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True, env=env)
     assert p.stdout is not None
@@ -46,6 +45,18 @@ def launch_proc_and_print(command: list[str], indent: str) -> int:
         print(textwrap.indent(line, indent).rstrip())
     print()
     return p.wait()
+
+
+def _update_term_size(indent: str) -> dict[str, str]:
+    try:
+        terminal_size = os.get_terminal_size()
+    except IOError:
+        return {}
+
+    env = {}
+    env["COLUMNS"] = str(terminal_size.columns - len(indent))
+    env["LINES"] = str(terminal_size.lines)
+    return env
 
 
 if __name__ == "__main__":

--- a/ci/launch.py
+++ b/ci/launch.py
@@ -1,6 +1,7 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 import argparse
+import os
 import subprocess
 import textwrap
 
@@ -29,21 +30,29 @@ def box(text: str) -> str:
     return "\n".join(string_builder)
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--indent", type=str, default=INDENT)
-    args, command = parser.parse_known_args()
+def launch_proc_and_print(command: list[str], indent: str) -> int:
+    # Set columns to current terminal size - indent.
+    env = os.environ.copy()
+    env["COLUMNS"] = str(os.get_terminal_size().columns - len(indent))
+    env["LINES"] = str(os.get_terminal_size().lines)
 
-    print(box(" ".join(command)))
-
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True, env=env)
     assert p.stdout is not None
 
     for line in p.stdout:
         if not line:
             continue
 
-        print(textwrap.indent(line, args.indent).rstrip())
+        print(textwrap.indent(line, indent).rstrip())
     print()
+    return p.wait()
 
-    raise SystemExit(p.wait())
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--indent", type=str, default=INDENT)
+    args, command = parser.parse_known_args()
+
+    print(box(" ".join(command)))
+    exit_code = launch_proc_and_print(command, args.indent)
+    raise SystemExit(exit_code)

--- a/ci/launch.py
+++ b/ci/launch.py
@@ -1,5 +1,6 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
+import shutil
 import argparse
 import os
 import subprocess
@@ -48,7 +49,7 @@ def launch_proc_and_print(command: list[str], indent: str) -> int:
 
 def term_size_env(indent: str) -> dict[str, str]:
     try:
-        terminal_size = os.get_terminal_size()
+        terminal_size = shutil.get_terminal_size()
     except IOError:
         return {}
 

--- a/ci/launch.py
+++ b/ci/launch.py
@@ -32,8 +32,7 @@ def box(text: str) -> str:
 
 def launch_proc_and_print(command: list[str], indent: str) -> int:
     # Set columns to current terminal size - indent.
-    env = os.environ.copy()
-    env.update(_update_term_size(indent))
+    env = {**os.environ, **term_size_env(indent)}
 
     p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True, env=env)
     assert p.stdout is not None
@@ -47,7 +46,7 @@ def launch_proc_and_print(command: list[str], indent: str) -> int:
     return p.wait()
 
 
-def _update_term_size(indent: str) -> dict[str, str]:
+def term_size_env(indent: str) -> dict[str, str]:
     try:
         terminal_size = os.get_terminal_size()
     except IOError:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "api", "build", "debugging", "docs", "faiss", "networkx", "pre-commit", "sklearn", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.1"
-content_hash = "sha256:5bf90d56fd05f47140c98db0ceb785ff8fa5cc387925c1969c8f9f47934f99ba"
+content_hash = "sha256:dabec2df740387ebe615a51e152e77ceca5562048503ac866a2a0b5535aefea2"
 
 [[metadata.targets]]
 requires_python = ">=3.14,<3.15"
@@ -4594,18 +4594,6 @@ files = [
 ]
 
 [[package]]
-name = "torchcodec"
-version = "0.10.0"
-requires_python = ">=3.10"
-summary = "A video decoder for PyTorch"
-groups = ["default"]
-files = [
-    {file = "torchcodec-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bb882c12ca07dcf6d82833db67e6b565693a4bccfeab6696697620e43e465556"},
-    {file = "torchcodec-0.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:bec2b938ad4b294bd71d0b0ab4976037c740be0c80be79e67803ebed4eff270e"},
-    {file = "torchcodec-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:4734eb82146516049e1070152eb3013d7b9689159ef35db7c0894d130d4e335d"},
-]
-
-[[package]]
 name = "torchmetrics"
 version = "1.9.0"
 requires_python = ">=3.10"
@@ -4797,7 +4785,7 @@ version = "2026.3"
 requires_python = ">=2"
 summary = "Provider of IANA time zone data"
 groups = ["default", "debugging"]
-marker = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or python_version >= \"3.9\""
+marker = "sys_platform == \"emscripten\" or sys_platform == \"win32\" or python_version >= \"3.9\""
 files = [
     {file = "tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931"},
     {file = "tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -835,7 +835,7 @@ files = [
 
 [[package]]
 name = "cryptography"
-version = "50.0.0"
+version = "50.0.1"
 requires_python = "!=3.9.0,!=3.9.1,>=3.9"
 summary = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 groups = ["api"]
@@ -844,46 +844,46 @@ dependencies = [
     "typing-extensions>=4.13.2; python_full_version < \"3.11\"",
 ]
 files = [
-    {file = "cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169"},
-    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f"},
-    {file = "cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105"},
-    {file = "cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef"},
-    {file = "cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30"},
-    {file = "cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d"},
-    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c"},
-    {file = "cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c"},
-    {file = "cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95"},
-    {file = "cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269"},
-    {file = "cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708"},
-    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47"},
-    {file = "cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9"},
-    {file = "cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7"},
-    {file = "cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba"},
-    {file = "cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9"},
+    {file = "cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527"},
+    {file = "cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a"},
+    {file = "cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959"},
+    {file = "cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b"},
+    {file = "cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648"},
+    {file = "cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6"},
+    {file = "cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3"},
+    {file = "cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6"},
+    {file = "cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149"},
+    {file = "cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf"},
+    {file = "cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80"},
+    {file = "cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239"},
+    {file = "cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558"},
+    {file = "cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e"},
+    {file = "cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2"},
+    {file = "cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20"},
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ files = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.59"
+version = "3.1.60"
 requires_python = ">=3.7"
 summary = "GitPython is a Python library used to interact with Git repositories"
 groups = ["tests"]
@@ -1365,8 +1365,8 @@ dependencies = [
     "typing-extensions>=3.10.0.2; python_version < \"3.10\"",
 ]
 files = [
-    {file = "gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c"},
-    {file = "gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4"},
+    {file = "gitpython-3.1.60-py3-none-any.whl", hash = "sha256:39548bffb8fa0f3a548133348868bb4838e79d73283052207dc97781a569b6b4"},
+    {file = "gitpython-3.1.60.tar.gz", hash = "sha256:e936431879fa85581b4311fa63492ea52251909e2d655b6529c704c904ddcc24"},
 ]
 
 [[package]]
@@ -4785,7 +4785,7 @@ version = "2026.3"
 requires_python = ">=2"
 summary = "Provider of IANA time zone data"
 groups = ["default", "debugging"]
-marker = "sys_platform == \"emscripten\" or sys_platform == \"win32\" or python_version >= \"3.9\""
+marker = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or python_version >= \"3.9\""
 files = [
     {file = "tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931"},
     {file = "tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,9 @@ dynamic = ["version"]
 dependencies = [
     "numpy>=2",
     "pandas>=3",
-    "torch==2.10.*",
+    "torch>=2",
     "tensordict>=0.11",
     "torchvision>=0.25",
-    "torchcodec==0.10.*",
     "rich>=14",
     "pillow>=12",
     "av>=17",


### PR DESCRIPTION
This is due to `torchcodec` version being tied to `torch`, which is annoying in developing on new machines.