### PR TITLE
Speed up imports

### DIFF
--- a/src/aioway/app/server.py
+++ b/src/aioway/app/server.py
@@ -10,33 +10,40 @@ if typing.TYPE_CHECKING:
 
 __all__ = ["serve", "fastapi_app", "fastmcp_app"]
 
+_FUNCTIONS: dict[str, cabc.Callable] = {}
+
 
 @functools.cache
 def fastapi_app() -> fastapi.FastAPI:
     "The public fastapi factory. If importing failed, return `NotImplemented`."
     try:
-        return _fastapi_app()
+        app = _fastapi_app()
     except ImportError:
         return NotImplemented
+
+    for path, func in _FUNCTIONS.items():
+        app.get(path)(func)
+
+    return app
 
 
 @functools.cache
 def fastmcp_app() -> fastmcp.FastMCP:
     "The public fastmcp factory. If importing failed, return `NotImplemented`."
     try:
-        return _fastmcp_app()
+        app = _fastmcp_app()
     except ImportError:
         return NotImplemented
+
+    for path, func in _FUNCTIONS.items():
+        app.tool(path)(func)
+
+    return app
 
 
 def serve[T: cabc.Callable](path: str) -> cabc.Callable[[T], T]:
     def decorator(func: T) -> T:
-        if (mcp := fastmcp_app()) is not NotImplemented:
-            mcp.tool()(func)
-
-        if (api := fastapi_app()) is not NotImplemented:
-            api.get(path)(func)
-
+        _FUNCTIONS[path] = func
         return func
 
     return decorator

--- a/src/aioway/trainers/static.py
+++ b/src/aioway/trainers/static.py
@@ -5,7 +5,6 @@ import dataclasses as dcls
 import typing
 from collections import abc as cabc
 
-import lightning as L
 import tensordict as td
 import torch
 from rich import progress
@@ -17,6 +16,9 @@ from aioway.dsets import Dset, InputTarget, InputTargetLikeDset
 from aioway.tspecs import TSpec, TSpecCompat
 
 from .steps import LossFunc, PredLossPair, TrainStep, ValidateStep
+
+if typing.TYPE_CHECKING:
+    import lightning as L
 
 __all__ = ["StaticTrainer", "TrainCfg"]
 

--- a/src/aioway/trainers/steps.py
+++ b/src/aioway/trainers/steps.py
@@ -6,12 +6,14 @@ import abc
 import dataclasses as dcls
 import typing
 
-import lightning as L
 import torch
 from torch import nn, optim
 
 from aioway._thunks import Thunk
 from aioway._utils import FloatArray
+
+if typing.TYPE_CHECKING:
+    import lightning as L
 
 __all__ = ["Step", "ValidateStep", "TrainStep", "IncSkLearnStep"]
 


### PR DESCRIPTION
Culprit: torch, lightning, fastmcp

Now torch is unavoidable as it's core,
but lightning is only for type hints now,
and fastmcp can be restructured to only register on initialization.

Fix #520 