### PR TITLE
Emitter / Rewriter outputs `nn.Module`s

### DIFF
--- a/src/aioway/emits/convs.py
+++ b/src/aioway/emits/convs.py
@@ -35,6 +35,7 @@ class ImageRegressorEmitter(Emitter):
     "The stride sizes."
 
     activation: Activation = "relu"
+    "The non linear activation to use."
 
     def _validate(self) -> None:
         _ = self._size

--- a/src/aioway/rewrites.py
+++ b/src/aioway/rewrites.py
@@ -1,0 +1,14 @@
+# Copyright (c) AIoWay Authors - All Rights Reserved
+
+"The rewriter module."
+from aioway.instrs import Instr
+
+import typing
+
+
+class Rewriter(typing.Protocol):
+    """
+    The rewriter rewrites an `Instr` into another.
+    """
+
+    def __call__(self, instr: Instr) -> Instr: ...

--- a/src/aioway/rewrites.py
+++ b/src/aioway/rewrites.py
@@ -1,14 +1,19 @@
 # Copyright (c) AIoWay Authors - All Rights Reserved
 
 "The rewriter module."
-from aioway.instrs import Instr
 
 import typing
+
+from aioway.instrs import Instr
+
+__all__ = ["Rewriter"]
 
 
 class Rewriter(typing.Protocol):
     """
     The rewriter rewrites an `Instr` into another.
+
+    Note: Switch this to `nn.Module` -> `nn.Module`.
     """
 
     def __call__(self, instr: Instr) -> Instr: ...


### PR DESCRIPTION
Decided that rewriter and emitter would emit `nn.Module`s to minimize code duplication. 

The parsing of configs (lifting), inferring tspec would be added as addons.

This, in terms of content, is a small PR.

Fix #491